### PR TITLE
드라이버 회원가입 페이지 뷰 구현

### DIFF
--- a/client/config/webpack.config.js
+++ b/client/config/webpack.config.js
@@ -338,18 +338,18 @@ module.exports = function (webpackEnv) {
     module: {
       strictExportPresence: true,
       rules: [
-        {
-          test: /\.css$/,
-          include: [/node_modules\/.*antd/],
-          use: [
-            {
-              loader: 'style-loader',
-            },
-            {
-              loader: 'css-loader',
-            },
-          ],
-        },
+        // {
+        //   test: /\.css$/,
+        //   include: [/node_modules\/.*antd/],
+        //   use: [
+        //     {
+        //       loader: 'style-loader',
+        //     },
+        //     {
+        //       loader: 'css-loader',
+        //     },
+        //   ],
+        // },
         // Disable require.ensure as it's not a standard language feature.
         { parser: { requireEnsure: false } },
         {
@@ -389,7 +389,7 @@ module.exports = function (webpackEnv) {
                 customize: require.resolve('babel-preset-react-app/webpack-overrides'),
 
                 plugins: [
-                  ['import', { libraryName: 'antd-mobile', style: 'css' }],
+                  // ['import', { libraryName: 'antd-mobile', style: 'css' }],
                   [
                     require.resolve('babel-plugin-named-asset-import'),
                     {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10312,6 +10312,32 @@
       "integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=",
       "dev": true
     },
+    "formik": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/formik/-/formik-2.2.5.tgz",
+      "integrity": "sha512-KkOsyYmh5xsow+wlbdL9QSkqvbiHSb1RIToBKiooCFW4lyypn+ZlHGjTuuOqUWBqZaI5nCEupeI275Mo6tFBzg==",
+      "requires": {
+        "deepmerge": "^2.1.1",
+        "hoist-non-react-statics": "^3.3.0",
+        "lodash": "^4.17.14",
+        "lodash-es": "^4.17.14",
+        "react-fast-compare": "^2.0.1",
+        "tiny-warning": "^1.0.2",
+        "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "deepmerge": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.2.1.tgz",
+          "integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA=="
+        },
+        "react-fast-compare": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+          "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+        }
+      }
+    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -13316,8 +13342,7 @@
     "lodash-es": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.15.tgz",
-      "integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==",
-      "dev": true
+      "integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -40,6 +40,7 @@
     "eslint-plugin-testing-library": "^3.9.2",
     "eslint-webpack-plugin": "^2.1.0",
     "file-loader": "6.1.1",
+    "formik": "^2.2.5",
     "fs-extra": "^9.0.1",
     "graphql": "^15.4.0",
     "html-webpack-plugin": "4.5.0",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -16,6 +16,10 @@ import {
   DriverSignupPage,
   NotFoundPage,
 } from './pages';
+import 'antd-mobile/lib/button/style/css';
+import 'antd-mobile/lib/list/style/css';
+import 'antd-mobile/lib/input-item/style/css';
+import 'antd-mobile/lib/toast/style/css';
 
 const App: React.FC = () => {
   return (

--- a/client/src/components/DriverSignupForm.tsx
+++ b/client/src/components/DriverSignupForm.tsx
@@ -1,0 +1,112 @@
+import React, { useState, useEffect } from 'react';
+import { Button } from 'antd-mobile';
+import { withFormik, FormikProps } from 'formik';
+import SignupLabelInput from './SignupLabelInput';
+import { driverSignupFormValues } from '../types';
+import 'antd-mobile/lib/button/style/css';
+
+const InnerForm: React.ElementType = ({ values, handleSubmit, setFieldValue }: FormikProps<driverSignupFormValues>) => {
+  const [disabled, setDisabled] = useState(true);
+
+  useEffect(() => {
+    if (!Object.values(values).every((value) => value.length > 0)) setDisabled(true);
+    else setDisabled(false);
+  }, [values]);
+
+  return (
+    <form>
+      <SignupLabelInput
+        title="아이디"
+        name="id"
+        placeholder="아이디를 입력해주세요"
+        type="text"
+        value={values.id}
+        setFieldValue={setFieldValue}
+      />
+      <SignupLabelInput
+        title="비밀번호"
+        name="password"
+        placeholder="비밀번호를 입력해주세요"
+        type="password"
+        value={values.password}
+        setFieldValue={setFieldValue}
+      />
+      <SignupLabelInput
+        title="이름"
+        name="userName"
+        placeholder="성함을 입력해주세요"
+        type="text"
+        value={values.userName}
+        setFieldValue={setFieldValue}
+      />
+      <SignupLabelInput
+        title="전화번호"
+        name="phoneNumber"
+        placeholder="전화번호를 입력해주세요"
+        type="text"
+        value={values.phoneNumber}
+        setFieldValue={setFieldValue}
+      />
+      <SignupLabelInput
+        title="면허번호"
+        name="licenseNumber"
+        placeholder="면허번호를 입력해주세요"
+        type="text"
+        value={values.licenseNumber}
+        setFieldValue={setFieldValue}
+      />
+      <SignupLabelInput
+        title="차종"
+        name="carName"
+        placeholder="차종을 입력해주세요"
+        type="text"
+        value={values.carName}
+        setFieldValue={setFieldValue}
+      />
+      <SignupLabelInput
+        title="차량 번호"
+        name="plateNumber"
+        placeholder="차 번호를 입력해주세요"
+        type="text"
+        value={values.plateNumber}
+        setFieldValue={setFieldValue}
+      />
+      <SignupLabelInput
+        title="차량 색상"
+        name="carColor"
+        placeholder="차량 색상을 입력해주세요"
+        type="text"
+        value={values.carColor}
+        setFieldValue={setFieldValue}
+      />
+      <Button
+        type="primary"
+        style={{ margin: '40px 20px' }}
+        onClick={(e: any) => {
+          handleSubmit(e);
+        }}
+        disabled={disabled}
+      >
+        회원가입
+      </Button>
+    </form>
+  );
+};
+
+const DriverSignupForm = withFormik({
+  mapPropsToValues: () => ({
+    id: '',
+    password: '',
+    userName: '',
+    phoneNumber: '',
+    licenseNumber: '',
+    carName: '',
+    plateNumber: '',
+    carColor: '',
+  }),
+  handleSubmit: (values, { setSubmitting, setErrors }) => {
+    console.log(values);
+  },
+})(InnerForm);
+
+export default DriverSignupForm;

--- a/client/src/components/DriverSignupForm.tsx
+++ b/client/src/components/DriverSignupForm.tsx
@@ -4,7 +4,6 @@ import { withFormik, FormikProps } from 'formik';
 import SignupLabelInput from './SignupLabelInput';
 import driverSignupValidation from '../utils/driverSignupValidation';
 import { driverSignupFormValues } from '../types';
-import 'antd-mobile/lib/button/style/css';
 
 const InnerForm: React.ElementType = ({
   values,

--- a/client/src/components/DriverSignupForm.tsx
+++ b/client/src/components/DriverSignupForm.tsx
@@ -2,10 +2,17 @@ import React, { useState, useEffect } from 'react';
 import { Button } from 'antd-mobile';
 import { withFormik, FormikProps } from 'formik';
 import SignupLabelInput from './SignupLabelInput';
+import driverSignupValidation from '../utils/driverSignupValidation';
 import { driverSignupFormValues } from '../types';
 import 'antd-mobile/lib/button/style/css';
 
-const InnerForm: React.ElementType = ({ values, handleSubmit, setFieldValue }: FormikProps<driverSignupFormValues>) => {
+const InnerForm: React.ElementType = ({
+  values,
+  handleSubmit,
+  setFieldValue,
+  isSubmitting,
+  errors,
+}: FormikProps<driverSignupFormValues>) => {
   const [disabled, setDisabled] = useState(true);
 
   useEffect(() => {
@@ -18,74 +25,76 @@ const InnerForm: React.ElementType = ({ values, handleSubmit, setFieldValue }: F
       <SignupLabelInput
         title="아이디"
         name="id"
-        placeholder="아이디를 입력해주세요"
-        type="text"
+        placeholder="아이디를 입력해주세요(6자 이상)"
         value={values.id}
         setFieldValue={setFieldValue}
+        error={errors.id}
       />
       <SignupLabelInput
         title="비밀번호"
         name="password"
-        placeholder="비밀번호를 입력해주세요"
+        placeholder="비밀번호를 입력해주세요(6자 이상)"
         type="password"
         value={values.password}
         setFieldValue={setFieldValue}
+        error={errors.password}
       />
       <SignupLabelInput
         title="이름"
         name="userName"
         placeholder="성함을 입력해주세요"
-        type="text"
         value={values.userName}
         setFieldValue={setFieldValue}
+        error={errors.userName}
       />
       <SignupLabelInput
         title="전화번호"
         name="phoneNumber"
         placeholder="전화번호를 입력해주세요"
-        type="text"
         value={values.phoneNumber}
         setFieldValue={setFieldValue}
+        error={errors.phoneNumber}
       />
       <SignupLabelInput
         title="면허번호"
         name="licenseNumber"
         placeholder="면허번호를 입력해주세요"
-        type="text"
         value={values.licenseNumber}
         setFieldValue={setFieldValue}
+        error={errors.licenseNumber}
       />
       <SignupLabelInput
         title="차종"
         name="carName"
         placeholder="차종을 입력해주세요"
-        type="text"
         value={values.carName}
         setFieldValue={setFieldValue}
+        error={errors.carName}
       />
       <SignupLabelInput
         title="차량 번호"
         name="plateNumber"
-        placeholder="차 번호를 입력해주세요"
-        type="text"
+        placeholder="차량 번호를 입력해주세요"
         value={values.plateNumber}
         setFieldValue={setFieldValue}
+        error={errors.plateNumber}
       />
       <SignupLabelInput
         title="차량 색상"
         name="carColor"
         placeholder="차량 색상을 입력해주세요"
-        type="text"
         value={values.carColor}
         setFieldValue={setFieldValue}
+        error={errors.carColor}
       />
       <Button
         type="primary"
+        loading={isSubmitting}
         style={{ margin: '40px 20px' }}
         onClick={(e: any) => {
           handleSubmit(e);
         }}
-        disabled={disabled}
+        disabled={disabled || isSubmitting}
       >
         회원가입
       </Button>
@@ -104,9 +113,13 @@ const DriverSignupForm = withFormik({
     plateNumber: '',
     carColor: '',
   }),
-  handleSubmit: (values, { setSubmitting, setErrors }) => {
-    console.log(values);
+  handleSubmit: (values, { setSubmitting }) => {
+    const { id, password, userName, phoneNumber, licenseNumber, carName, plateNumber, carColor } = values;
+    setSubmitting(true);
+
+    // TODO: 입력값을 토대로 서버에 회원가입 요청
   },
+  validate: driverSignupValidation,
 })(InnerForm);
 
 export default DriverSignupForm;

--- a/client/src/components/SignupLabelInput.tsx
+++ b/client/src/components/SignupLabelInput.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { List, InputItem } from 'antd-mobile';
+import styled from 'styled-components';
+import { signupLabelInputProps } from '../types';
+import 'antd-mobile/lib/list/style/css';
+import 'antd-mobile/lib/input-item/style/css';
+
+const SignupLabelInput: React.FC<signupLabelInputProps> = ({
+  title,
+  name,
+  placeholder,
+  type,
+  value,
+  setFieldValue,
+}) => {
+  return (
+    <Wrapper>
+      <List renderHeader={() => title}>
+        <InputItem
+          clear
+          placeholder={placeholder}
+          name={name}
+          type={type}
+          value={value}
+          onChange={(e) => {
+            setFieldValue(name, e);
+          }}
+        />
+      </List>
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled.div`
+  margin: 10px 20px;
+`;
+
+export default SignupLabelInput;

--- a/client/src/components/SignupLabelInput.tsx
+++ b/client/src/components/SignupLabelInput.tsx
@@ -2,9 +2,6 @@ import React, { useState } from 'react';
 import { List, InputItem, Toast } from 'antd-mobile';
 import styled from 'styled-components';
 import { signupLabelInputProps } from '../types';
-import 'antd-mobile/lib/list/style/css';
-import 'antd-mobile/lib/input-item/style/css';
-import 'antd-mobile/lib/toast/style/css';
 
 const SignupLabelInput: React.FC<signupLabelInputProps> = ({
   title,

--- a/client/src/components/SignupLabelInput.tsx
+++ b/client/src/components/SignupLabelInput.tsx
@@ -1,18 +1,22 @@
-import React from 'react';
-import { List, InputItem } from 'antd-mobile';
+import React, { useState } from 'react';
+import { List, InputItem, Toast } from 'antd-mobile';
 import styled from 'styled-components';
 import { signupLabelInputProps } from '../types';
 import 'antd-mobile/lib/list/style/css';
 import 'antd-mobile/lib/input-item/style/css';
+import 'antd-mobile/lib/toast/style/css';
 
 const SignupLabelInput: React.FC<signupLabelInputProps> = ({
   title,
   name,
   placeholder,
-  type,
+  type = 'text',
   value,
   setFieldValue,
+  error,
 }) => {
+  const [visited, setVisited] = useState(false);
+
   return (
     <Wrapper>
       <List renderHeader={() => title}>
@@ -23,7 +27,12 @@ const SignupLabelInput: React.FC<signupLabelInputProps> = ({
           type={type}
           value={value}
           onChange={(e) => {
+            if (!visited) setVisited(true);
             setFieldValue(name, e);
+          }}
+          error={visited && !!error}
+          onErrorClick={() => {
+            Toast.info(error);
           }}
         />
       </List>

--- a/client/src/pages/driver/DriverSignupPage.tsx
+++ b/client/src/pages/driver/DriverSignupPage.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
+import DriverSignupForm from '../../components/DriverSignupForm';
 
 const DriverSignupPage: React.FC = () => {
-  return <div>드라이버 회원가입 페이지</div>;
+  return (
+    <>
+      <DriverSignupForm />
+    </>
+  );
 };
 
 export default DriverSignupPage;

--- a/client/src/stories/SignupLabelInput.stories.tsx
+++ b/client/src/stories/SignupLabelInput.stories.tsx
@@ -1,0 +1,29 @@
+import React, { useState } from 'react';
+import { Meta } from '@storybook/react/types-6-0';
+import { text } from '@storybook/addon-knobs';
+
+import SignupLabelTitle from '../components/SignupLabelInput';
+
+export default {
+  title: 'SignupLabelTitle',
+  component: SignupLabelTitle,
+} as Meta;
+
+export const signupLabelAndTitle: React.FC = () => {
+  const name = 'example';
+  const [value, setValue] = useState('');
+  const setFieldValue = (_, e) => {
+    setValue(e);
+  };
+
+  return (
+    <SignupLabelTitle
+      title={text('타이틀', '아이디')}
+      name={name}
+      placeholder={text('기본 문구', '아이디를 입력하세요')}
+      type="text"
+      value={value}
+      setFieldValue={setFieldValue}
+    />
+  );
+};

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -1,0 +1,19 @@
+export interface signupLabelInputProps {
+  title: string;
+  placeholder: string;
+  name: string;
+  type: 'number' | 'text' | 'phone' | 'password';
+  value: string;
+  setFieldValue: any;
+}
+
+export interface driverSignupFormValues {
+  id: string;
+  password: string;
+  userName: string;
+  phoneNumber: string;
+  licenseNumber: string;
+  carName: string;
+  plateNumber: string;
+  carColor: string;
+}

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -2,9 +2,10 @@ export interface signupLabelInputProps {
   title: string;
   placeholder: string;
   name: string;
-  type: 'number' | 'text' | 'phone' | 'password';
+  type?: 'number' | 'text' | 'phone' | 'password';
   value: string;
   setFieldValue: any;
+  error: string | undefined;
 }
 
 export interface driverSignupFormValues {

--- a/client/src/utils/driverSignupValidation.ts
+++ b/client/src/utils/driverSignupValidation.ts
@@ -1,0 +1,27 @@
+import { driverSignupFormValues } from '../types';
+
+const driverSignupValidation: any = (values: driverSignupFormValues) => {
+  const necessaryMessage = '필수 항목입니다';
+  const wrongFormatMessage = '잘못된 양식입니다';
+  const { id, password, userName, phoneNumber, licenseNumber, carName, plateNumber, carColor } = values;
+
+  if (!id.length) return { id: necessaryMessage };
+  if (!password.length) return { password: necessaryMessage };
+  if (!userName.length) return { userName: necessaryMessage };
+  if (!phoneNumber.length) return { phoneNumber: necessaryMessage };
+  if (!licenseNumber.length) return { licenseNumber: necessaryMessage };
+  if (!carName.length) return { carName: necessaryMessage };
+  if (!plateNumber.length) return { plateNumber: necessaryMessage };
+  if (!carColor.length) return { carColor: necessaryMessage };
+
+  if (id.length < 6) return { id: '아이디는 6자리 이상이어야 합니다' };
+  if (id.split(' ').length !== 1) return { id: wrongFormatMessage };
+
+  if (password.length < 6) return { password: '비밀번호는 6자리 이상이어야 합니다' };
+  if (password.split(' ').length !== 1) return { password: wrongFormatMessage };
+
+  const phoneNumberRegex = /^\d{7,20}$/;
+  if (!phoneNumberRegex.test(phoneNumber.split('-').join(''))) return { phoneNumber: wrongFormatMessage };
+};
+
+export default driverSignupValidation;

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -17,5 +17,6 @@
     "noEmit": true,
     "jsx": "react"
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx"]
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["src/stories/*"]
 }


### PR DESCRIPTION
## 해당 이슈 📎

#16 

## 변경 사항 🛠

- SignupLabelInput 컴포넌트 생성
  - 제목과 이름, placeholder 등을 props로 받아 보여주는 컴포넌트입니다
  - 회원가입 폼의 최소단위입니다
- Formik 라이브러리로 폼 관리
  - 라이브러리 내 withFormik 함수를 활용했습니다
  - **사용한 이유**는 antd-mobile에 별도로 폼이 없었기 때문입니다
  -  validate로 입력값을 검증했습니다. utils 폴더 내 별도의 함수로 분리되어 있습니다.

## 테스트 ✨

![드라이버 회원가입](https://user-images.githubusercontent.com/34625313/100119637-6e0be480-2eba-11eb-9129-db3d5ca2cc7f.gif)


## 리뷰어 참고 사항 🙋‍♀️

- SignupInputLabel 재사용하시어요
- 뭔가 반복되는 게 많긴 한데 어떻게 분리할지 잘 모르겠네요... 조언 부탁드립니다
