### PR TITLE
로비(auth) 페이지 구현

### DIFF
--- a/client/src/components/EntryButtonGroup.tsx
+++ b/client/src/components/EntryButtonGroup.tsx
@@ -20,7 +20,7 @@ const EntryButtonGroup: React.FC<RouteComponentProps> = ({ history }) => {
       <Button
         type="primary"
         onClick={() => {
-          history.push('/user');
+          history.push('/driver');
           return;
         }}
       >

--- a/client/src/components/UserAuthPage/AuthButtonGroup.tsx
+++ b/client/src/components/UserAuthPage/AuthButtonGroup.tsx
@@ -3,13 +3,17 @@ import styled from 'styled-components';
 import { Button, WhiteSpace } from 'antd-mobile';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 
-const AuthButtonGroup: React.FC<RouteComponentProps> = ({ history }) => {
+interface Props {
+  who: string;
+}
+
+const AuthButtonGroup: React.FC<RouteComponentProps & Props> = ({ history, who }) => {
   return (
     <Div>
       <Button
         type="primary"
         onClick={() => {
-          history.push('/user/signup');
+          history.push(`/${who}/signup`);
           return;
         }}
       >
@@ -20,7 +24,7 @@ const AuthButtonGroup: React.FC<RouteComponentProps> = ({ history }) => {
       <Button
         type="primary"
         onClick={() => {
-          history.push('/user/signin');
+          history.push(`/${who}/signin`);
           return;
         }}
       >

--- a/client/src/components/UserAuthPage/AuthButtonGroup.tsx
+++ b/client/src/components/UserAuthPage/AuthButtonGroup.tsx
@@ -4,16 +4,16 @@ import { Button, WhiteSpace } from 'antd-mobile';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 
 interface Props {
-  who: string;
+  userType: string;
 }
 
-const AuthButtonGroup: React.FC<RouteComponentProps & Props> = ({ history, who }) => {
+const AuthButtonGroup: React.FC<RouteComponentProps & Props> = ({ history, userType }) => {
   return (
     <Div>
       <Button
         type="primary"
         onClick={() => {
-          history.push(`/${who}/signup`);
+          history.push(`/${userType}/signup`);
           return;
         }}
       >
@@ -24,7 +24,7 @@ const AuthButtonGroup: React.FC<RouteComponentProps & Props> = ({ history, who }
       <Button
         type="primary"
         onClick={() => {
-          history.push(`/${who}/signin`);
+          history.push(`/${userType}/signin`);
           return;
         }}
       >

--- a/client/src/components/UserAuthPage/AuthButtonGroup.tsx
+++ b/client/src/components/UserAuthPage/AuthButtonGroup.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Button, WhiteSpace } from 'antd-mobile';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
+
+const AuthButtonGroup: React.FC<RouteComponentProps> = ({ history }) => {
+  return (
+    <Div>
+      <Button
+        type="primary"
+        onClick={() => {
+          history.push('/user/signup');
+          return;
+        }}
+      >
+        회원가입
+      </Button>
+      <WhiteSpace />
+      <br />
+      <Button
+        type="primary"
+        onClick={() => {
+          history.push('/user/signin');
+          return;
+        }}
+      >
+        로그인
+      </Button>
+    </Div>
+  );
+};
+
+const Div = styled.div`
+  width: 80%;
+`;
+
+export default withRouter(AuthButtonGroup);

--- a/client/src/pages/driver/DriverAuthPage.tsx
+++ b/client/src/pages/driver/DriverAuthPage.tsx
@@ -10,7 +10,7 @@ const UserAuthPage: React.FC = () => {
         <p>안녕하세요,</p>
         <p>운전대 잡으려면 로그인 해주세요.</p>
       </div>
-      <AuthButtonGroup who={'driver'} />
+      <AuthButtonGroup userType={'driver'} />
     </Div>
   );
 };

--- a/client/src/pages/driver/DriverAuthPage.tsx
+++ b/client/src/pages/driver/DriverAuthPage.tsx
@@ -20,7 +20,6 @@ const Div = styled.div`
   flex-direction: column;
   align-items: center;
   height: 100vh;
-  border: 1px solid;
   justify-content: space-around;
 `;
 

--- a/client/src/pages/driver/DriverAuthPage.tsx
+++ b/client/src/pages/driver/DriverAuthPage.tsx
@@ -1,7 +1,32 @@
 import React from 'react';
+import styled from 'styled-components';
+import AuthButtonGroup from '../../components/UserAuthPage/AuthButtonGroup';
 
-const DriverAuthPage: React.FC = () => {
-  return <div>드라이버 로그인, 회원가입 선택 페이지</div>;
+const UserAuthPage: React.FC = () => {
+  return (
+    <Div>
+      <H1>자버택시</H1>
+      <div>
+        <p>안녕하세요,</p>
+        <p>운전대 잡으려면 로그인 해주세요.</p>
+      </div>
+      <AuthButtonGroup who={'driver'} />
+    </Div>
+  );
 };
 
-export default DriverAuthPage;
+const Div = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  height: 100vh;
+  border: 1px solid;
+  justify-content: space-around;
+`;
+
+const H1 = styled.h1`
+  font-size: 30px;
+  font-weight: 600;
+`;
+
+export default UserAuthPage;

--- a/client/src/pages/driver/DriverAuthPage.tsx
+++ b/client/src/pages/driver/DriverAuthPage.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import AuthButtonGroup from '../../components/UserAuthPage/AuthButtonGroup';
 
-const UserAuthPage: React.FC = () => {
+const DriverAuthPage: React.FC = () => {
   return (
     <Div>
       <H1>자버택시</H1>
@@ -28,4 +28,4 @@ const H1 = styled.h1`
   font-weight: 600;
 `;
 
-export default UserAuthPage;
+export default DriverAuthPage;

--- a/client/src/pages/user/UserAuthPage.tsx
+++ b/client/src/pages/user/UserAuthPage.tsx
@@ -6,7 +6,11 @@ const UserAuthPage: React.FC = () => {
   return (
     <Div>
       <H1>자버택시</H1>
-      <AuthButtonGroup />
+      <div>
+        <p>안녕하세요,</p>
+        <p>자버택시 잡으려면 로그인 해주세요.</p>
+      </div>
+      <AuthButtonGroup who={'user'} />
     </Div>
   );
 };

--- a/client/src/pages/user/UserAuthPage.tsx
+++ b/client/src/pages/user/UserAuthPage.tsx
@@ -20,7 +20,6 @@ const Div = styled.div`
   flex-direction: column;
   align-items: center;
   height: 100vh;
-  border: 1px solid;
   justify-content: space-around;
 `;
 

--- a/client/src/pages/user/UserAuthPage.tsx
+++ b/client/src/pages/user/UserAuthPage.tsx
@@ -1,7 +1,28 @@
 import React from 'react';
+import styled from 'styled-components';
+import AuthButtonGroup from '../../components/UserAuthPage/AuthButtonGroup';
 
 const UserAuthPage: React.FC = () => {
-  return <div>유저 로그인, 회원가입 선택 페이지</div>;
+  return (
+    <Div>
+      <H1>자버택시</H1>
+      <AuthButtonGroup />
+    </Div>
+  );
 };
+
+const Div = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  height: 100vh;
+  border: 1px solid;
+  justify-content: space-around;
+`;
+
+const H1 = styled.h1`
+  font-size: 30px;
+  font-weight: 600;
+`;
 
 export default UserAuthPage;

--- a/client/src/pages/user/UserAuthPage.tsx
+++ b/client/src/pages/user/UserAuthPage.tsx
@@ -10,7 +10,7 @@ const UserAuthPage: React.FC = () => {
         <p>안녕하세요,</p>
         <p>자버택시 잡으려면 로그인 해주세요.</p>
       </div>
-      <AuthButtonGroup who={'user'} />
+      <AuthButtonGroup userType={'user'} />
     </Div>
   );
 };


### PR DESCRIPTION
## 해당 이슈 📎

로비 페이지 구현 #29

## 변경 사항 🛠

- 유저/드라이버 로비에서 회원가입/로그인 버튼을 누르면 해당 페이지로 이동합니다. 

## 테스트 ✨

![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/45927473/100252728-8c89e280-2f83-11eb-973c-a9a59798c983.gif)


## 리뷰어 참고 사항 🙋‍♀️

- 저녁 회의 시간 때 말 한 빠진 백로그와 이슈 추가하고 구현했습니다, 어려운건 없었어요! 
- 아쉬운 점
  - styled-component도 재사용 하고싶고.. 
  - storybook도 전혀 못 활용하고 있는 상태입니다만,,
  - 리팩토링은 주말 과제로 남겨두도록 하겠읍니다,, 
- SNS 로그인 버튼은 추후 OAuth 구현시 추가하도록 할게요!
