### PR TITLE
매칭 요청 전 유저 맵 하단에 노출되는 컴포넌트 구현

### DIFF
--- a/client/src/components/userMain/PreReqData.tsx
+++ b/client/src/components/userMain/PreReqData.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import styled from 'styled-components';
+import dataDiv from '../userMain/DataDiv';
+import RequestButton from './RequsetButton';
+
+// TODO : 입시값입니다 - 데이터 받아오면 지워주세요
+const preCalTime = 20;
+const preCalCost = '15,000';
+
+const PreReqData: React.FC = () => {
+  const preReqData = () => {
+    return (
+      <>
+        <Div>
+          <p>예상시간</p>
+          <P>{preCalTime}분</P>
+        </Div>
+        <Div>
+          <p>예상요금</p>
+          <P>{preCalCost}원</P>
+        </Div>
+        <hr />
+        <RequestButton />
+      </>
+    );
+  };
+
+  const PreReqDataCompo = dataDiv(preReqData);
+  return <PreReqDataCompo putOn="bottom" />;
+};
+
+const Div = styled.div`
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const P = styled.p`
+  font-size: 20px;
+`;
+
+export default PreReqData;

--- a/client/src/components/userMain/PreReqData.tsx
+++ b/client/src/components/userMain/PreReqData.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import styled from 'styled-components';
-import dataDiv from '../userMain/DataDiv';
+import ContentWrapper from './ContentWrapper';
 import RequestButton from './RequsetButton';
 
 // TODO : 입시값입니다 - 데이터 받아오면 지워주세요
 const preCalTime = 20;
 const preCalCost = '15,000';
 
-const PreReqData: React.FC = () => {
+const PreRequestData: React.FC = () => {
   const preReqData = () => {
     return (
       <>
@@ -25,8 +25,8 @@ const PreReqData: React.FC = () => {
     );
   };
 
-  const PreReqDataCompo = dataDiv(preReqData);
-  return <PreReqDataCompo putOn="bottom" />;
+  const PreRequestDataComponent = ContentWrapper(preReqData);
+  return <PreRequestDataComponent putOn="bottom" />;
 };
 
 const Div = styled.div`
@@ -40,4 +40,4 @@ const P = styled.p`
   font-size: 20px;
 `;
 
-export default PreReqData;
+export default PreRequestData;

--- a/client/src/components/userMain/RequsetButton.tsx
+++ b/client/src/components/userMain/RequsetButton.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Button } from 'antd-mobile';
+import { useHistory } from 'react-router-dom';
+
+const MatchingReqBtn: React.FC = () => {
+  const history = useHistory();
+  const handlClick = async () => {
+    history.push('/user/matching');
+  };
+  return (
+    <Button onClick={handlClick} type="primary">
+      택시자버 요청하기
+    </Button>
+  );
+};
+
+export default MatchingReqBtn;

--- a/client/src/pages/user/UserMainPage.tsx
+++ b/client/src/pages/user/UserMainPage.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect } from 'react';
+import { Loader } from '@googlemaps/js-api-loader';
 import MapContainer from '../../containers/MapContainer';
 import InputPlaces from '@components/userMain/InputPlaces';
-import { Loader } from '@googlemaps/js-api-loader';
+import PreReqData from '@components/userMain/PreReqData';
 
 const loader = new Loader({
   apiKey: process.env.REACT_APP_GOOGLE_MAP_API_KEY || '',
@@ -25,7 +26,9 @@ const UserMainPage: React.FC = () => {
       {apiLoaded && (
         <>
           <InputPlaces />
-          <MapContainer />;
+          <MapContainer />
+          {/* TODO : 출발/도착지 모두 선택시 노출 */}
+          <PreReqData />;
         </>
       )}
     </>

--- a/client/src/pages/user/UserMatchingPage.tsx
+++ b/client/src/pages/user/UserMatchingPage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const UserMatchingPage: React.FC = () => {
-  return <div>유저 메인 페이지</div>;
+  return <div>유저 매칭중 페이지</div>;
 };
 
 export default UserMatchingPage;


### PR DESCRIPTION
## 해당 이슈 📎

매칭 시작 클릭 시 매칭 중 페이지로 이동 #22

## 변경 사항 🛠
- `PreReqData` 
  - 예상시간 | 예상요금 | 매칭요청버튼 을 감싸는 컴포넌트입니다.
  - 디스플레이 하단에 위치합니다. 
- `RequestButton` 클릭시 `/user/matching` 로 페이지 이동

## 테스트 ✨
<img src='https://user-images.githubusercontent.com/45927473/100710941-d9dad980-33f3-11eb-8a22-71ac923cd087.png' width='300px'>


## 리뷰어 참고 사항 🙋‍♀️

- @2hoyeong  호영님  26번 백로그 관련 이슈는 #22 번 이슈에 이어서 해주시면 됩니다! 
- TODO : `PreReqData` 는 출발지/도착지 입력 완료시 노출됩니다. 
  - 요거는 지금 담당자가 따로 없는데..! 우선 이슈에 올려놓겠습니다. 업무 여유되시는 분 커버 부탁드려요! 
  - 이번PR에서 제가 했었어야 했나 싶은데..
    - 이슈범위가 UI이고, 이 UI가 빨리 머지되어야 호영님, 소희님 다음 작업이 용이할 듯 해서 우선 PR합니다!
