### PR TITLE
드라이버 - 탑승 완료 버튼 구현

### DIFF
--- a/client/src/components/common/CallButton.tsx
+++ b/client/src/components/common/CallButton.tsx
@@ -10,7 +10,7 @@ const CallButton: React.FC<CallButtonPropsType> = ({ phone }) => {
   };
   return (
     <Button
-      style={{ margin: '10px', backgroundColor: '#cccccc', cursor: 'pointer', position: 'relative' }}
+      style={{ backgroundColor: '#cccccc', cursor: 'pointer', position: 'relative' }}
       icon={<img src="https://img.icons8.com/ios-filled/48/000000/phone.png" />}
       onClick={onClick}
     />

--- a/client/src/pages/driver/DriverMatchingPage.tsx
+++ b/client/src/pages/driver/DriverMatchingPage.tsx
@@ -1,24 +1,47 @@
-import React from 'react';
+import React, { useState } from 'react';
 import MapContainer from '../../containers/MapContainer';
 import CallButton from '@components/common/CallButton';
 import styled from 'styled-components';
+import { Button } from 'antd-mobile';
 
 const DriverMatchingPage: React.FC = () => {
+  const [state, setState] = useState(false);
+
   return (
     <>
       <MapContainer />
-      <Overlay>
-        <CallButton phone="010-0000-0000" />
-      </Overlay>
+      {state ? (
+        <> // TODO: 승객 탑승 후 컴포넌트</>
+      ) : (
+        <>
+          <TopOverlay>
+            <CallButton phone="010-0000-0000" />
+          </TopOverlay>
+          <BottomOverlay>
+            <Button type="primary" onClick={() => setState(true)}>
+              승객 탑승 완료
+            </Button>
+          </BottomOverlay>
+        </>
+      )}
     </>
   );
 };
 
-const Overlay = styled.div`
+const TopOverlay = styled.div`
   position: absolute;
   top: 0;
   left: 0;
   right: 0;
+  margin: 10px;
+`;
+
+const BottomOverlay = styled.div`
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  margin: 10px;
 `;
 
 export default DriverMatchingPage;

--- a/client/src/pages/driver/DriverMatchingPage.tsx
+++ b/client/src/pages/driver/DriverMatchingPage.tsx
@@ -5,12 +5,12 @@ import styled from 'styled-components';
 import { Button } from 'antd-mobile';
 
 const DriverMatchingPage: React.FC = () => {
-  const [state, setState] = useState(false);
+  const [boarding, setBoarding] = useState(false);
 
   return (
     <>
       <MapContainer />
-      {state ? (
+      {boarding ? (
         <> // TODO: 승객 탑승 후 컴포넌트</>
       ) : (
         <>
@@ -18,7 +18,7 @@ const DriverMatchingPage: React.FC = () => {
             <CallButton phone="010-0000-0000" />
           </TopOverlay>
           <BottomOverlay>
-            <Button type="primary" onClick={() => setState(true)}>
+            <Button type="primary" onClick={() => setBoarding(true)}>
               승객 탑승 완료
             </Button>
           </BottomOverlay>

--- a/client/src/pages/user/UserMatchingPage.tsx
+++ b/client/src/pages/user/UserMatchingPage.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { gql, useSubscription } from '@apollo/client';
 import { Loader } from '@googlemaps/js-api-loader';
-import MatchedDriverData from '@components/UserMatching/MatchedDriverData';
+import MatchedDriverData from '@components/userMatching/MatchedDriverData';
 import MapContainer from '../../containers/MapContainer';
 import { Toast } from 'antd-mobile';
 import Matching from '@components/userMatching/Matching';


### PR DESCRIPTION
## 해당 이슈 📎

#49  #72 #79 

## 변경 사항 🛠

- 승객 탑승 완료 버튼을 구현하였습니다. (#49)
    - 탑승  상태로 탑승 전과 탑승 후에 띄울 컴포넌트를 설정합니다.
- 통화 버튼 margin 속성을 삭제했습니다. (#72)
- UserMatching페이지에서 사용되는 컴포넌트의 경로가 잘못되어서 수정했습니다 (#79)

## 테스트 ✨
- 탑승 전
![탑승 전](https://user-images.githubusercontent.com/61968474/100878208-35d55900-34ed-11eb-998e-1b023872fe08.PNG)
- 탑승 후
![탑승 후](https://user-images.githubusercontent.com/61968474/100878215-379f1c80-34ed-11eb-8bd8-dbfb154ffd27.PNG)

## 리뷰어 참고 사항 🙋‍♀️
- 이후에 탑승 후의 컴포넌트를 추가해주면 될 것 같습니다!!
