### PR TITLE
Production 환경에서 SSL 적용

### DIFF
--- a/client/src/utils/apolloClient.ts
+++ b/client/src/utils/apolloClient.ts
@@ -3,7 +3,7 @@ import { getMainDefinition } from '@apollo/client/utilities';
 import { WebSocketLink } from '@apollo/client/link/ws';
 
 const httpLink = new HttpLink({
-  uri: `${process.env.NODE_ENV === 'production' ? 'https' : 'http'}//${process.env.REACT_APP_SERVER_HOST}/graphql`,
+  uri: `${process.env.NODE_ENV === 'production' ? 'https' : 'http'}://${process.env.REACT_APP_SERVER_HOST}/graphql`,
   credentials: 'include',
 });
 

--- a/client/src/utils/apolloClient.ts
+++ b/client/src/utils/apolloClient.ts
@@ -3,12 +3,12 @@ import { getMainDefinition } from '@apollo/client/utilities';
 import { WebSocketLink } from '@apollo/client/link/ws';
 
 const httpLink = new HttpLink({
-  uri: `http://${process.env.REACT_APP_SERVER_HOST}/graphql`,
+  uri: `${process.env.NODE_ENV === 'production' ? 'https' : 'http'}//${process.env.REACT_APP_SERVER_HOST}/graphql`,
   credentials: 'include',
 });
 
 const wsLink = new WebSocketLink({
-  uri: `ws://${process.env.REACT_APP_SERVER_HOST}/graphql`,
+  uri: `${process.env.NODE_ENV === 'production' ? 'wss' : 'ws'}://${process.env.REACT_APP_SERVER_HOST}/graphql`,
   options: {
     reconnect: true,
   },


### PR DESCRIPTION
production 환경에서 https로 통신하기 때문에 그에 대응하기 위해 graphql과 웹소켓이 SSL이 적용된 프로토콜로 통신하도록 하였습니다.

## 해당 이슈 📎

## 변경 사항 🛠

- graphql https로 연결되도록 설정
- 웹소켓 wss로 연결되도록 설정

## 테스트 ✨

없음

## 리뷰어 참고 사항 🙋‍♀️

- 팀원에게 하고 싶은 말
