### PR TITLE
맵 컨테이너, 맵 컴포넌트 관련 리팩토링 진행

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -21,6 +21,7 @@ import {
 import { AuthRouter, UserRouter, DriverRouter } from '@components/routers';
 
 import { Provider } from 'react-redux';
+import GoogleMapProvider from './contexts/GoogleMapProvider';
 import store from './stores';
 
 import 'antd-mobile/lib/button/style/css';
@@ -36,22 +37,24 @@ const App: React.FC = () => {
   return (
     <Provider store={store}>
       <ApolloProvider client={client}>
-        <BrowserRouter>
-          <Switch>
-            <Route exact path="/" component={UserDriverSelectPage} />
-            <AuthRouter exact path="/user" component={UserAuthPage} />
-            <AuthRouter path="/user/signup" component={UserSignupPage} />
-            <AuthRouter path="/user/signin" component={UserSigninPage} />
-            <UserRouter path="/user/map" component={UserMainPage} />
-            <UserRouter path="/user/matching" component={UserMatchingPage} />
-            <AuthRouter exact path="/driver" component={DriverAuthPage} />
-            <AuthRouter path="/driver/signup" component={DriverSignupPage} />
-            <AuthRouter path="/driver/signin" component={DriverSigninPage} />
-            <DriverRouter path="/driver/main" component={DriverMainPage} />
-            <DriverRouter path="/driver/map" component={DriverMatchingPage} />
-            <Route component={NotFoundPage} />
-          </Switch>
-        </BrowserRouter>
+        <GoogleMapProvider>
+          <BrowserRouter>
+            <Switch>
+              <Route exact path="/" component={UserDriverSelectPage} />
+              <AuthRouter exact path="/user" component={UserAuthPage} />
+              <AuthRouter path="/user/signup" component={UserSignupPage} />
+              <AuthRouter path="/user/signin" component={UserSigninPage} />
+              <UserRouter path="/user/map" component={UserMainPage} />
+              <UserRouter path="/user/matching" component={UserMatchingPage} />
+              <AuthRouter exact path="/driver" component={DriverAuthPage} />
+              <AuthRouter path="/driver/signup" component={DriverSignupPage} />
+              <AuthRouter path="/driver/signin" component={DriverSigninPage} />
+              <DriverRouter path="/driver/main" component={DriverMainPage} />
+              <DriverRouter path="/driver/map" component={DriverMatchingPage} />
+              <Route component={NotFoundPage} />
+            </Switch>
+          </BrowserRouter>
+        </GoogleMapProvider>
       </ApolloProvider>
     </Provider>
   );

--- a/client/src/components/map/Map.tsx
+++ b/client/src/components/map/Map.tsx
@@ -5,29 +5,19 @@ import TaxiMarker from '@components/common/TaxiMarker';
 import { Location, PathPoint } from '@custom-types';
 import { updatePath } from '@stores/modules/preData';
 import { useDispatch } from 'react-redux';
+import { useGoogleMapApiState } from 'src/contexts/GoogleMapProvider';
 
 const Map: React.FC<{
   center: Location;
   location: Location;
   pathPoint: PathPoint;
-  zoom: number;
-  directionRenderer: any;
   updateMyLocation: () => void;
   isMatched: boolean;
   taxiLocation: Location;
   findNearPlace: (map: any) => void;
-}> = ({
-  center,
-  location,
-  pathPoint,
-  zoom,
-  updateMyLocation,
-  isMatched,
-  taxiLocation,
-  directionRenderer,
-  findNearPlace,
-}) => {
+}> = ({ center, location, pathPoint, updateMyLocation, isMatched, taxiLocation, findNearPlace }) => {
   const [maps, setMaps]: any = useState({ map: null });
+  const { directionRenderer } = useGoogleMapApiState();
   const dispatch = useDispatch();
   const renderDirection: (result: google.maps.DirectionsResult, status: google.maps.DirectionsStatus) => void = (
     result,
@@ -68,7 +58,7 @@ const Map: React.FC<{
     <div style={{ height: '100vh', width: '100%' }}>
       <GoogleMapReact
         bootstrapURLKeys={{ key: process.env.REACT_APP_GOOGLE_MAP_API_KEY || '', libraries: ['places'] }}
-        defaultZoom={zoom}
+        defaultZoom={16}
         center={center}
         onGoogleApiLoaded={setMaps}
         onTilesLoaded={() => {
@@ -86,14 +76,6 @@ const Map: React.FC<{
       </GoogleMapReact>
     </div>
   );
-};
-
-Map.defaultProps = {
-  center: {
-    lat: 37.5006226,
-    lng: 127.0231786,
-  },
-  zoom: 16,
 };
 
 export default Map;

--- a/client/src/components/map/Map.tsx
+++ b/client/src/components/map/Map.tsx
@@ -23,7 +23,7 @@ const Map: React.FC<{
     result,
     status,
   ) => {
-    if (status === google.maps.DirectionsStatus.OK) {
+    if (status === google.maps.DirectionsStatus.OK && directionRenderer) {
       const distance = result.routes[0].legs[0].distance;
       const duration = result.routes[0].legs[0].duration;
       const calc = 3800 + ((distance.value - 2000) / 110 + duration.value / 31) * 100;

--- a/client/src/components/map/Map.tsx
+++ b/client/src/components/map/Map.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import GoogleMapReact from 'google-map-react';
 import Marker from '@components/common/Marker';
 import TaxiMarker from '@components/common/TaxiMarker';
@@ -32,10 +32,6 @@ const Map: React.FC<{
       directionRenderer.setDirections(result);
     }
   };
-
-  useEffect(() => {
-    setInterval(updateMyLocation, 1000);
-  }, []);
 
   useEffect(() => {
     const { startPoint, endPoint } = pathPoint;

--- a/client/src/components/userMain/InputPlaces.tsx
+++ b/client/src/components/userMain/InputPlaces.tsx
@@ -1,12 +1,25 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import ContentWrapper from '@components/common/ContentWrapper';
 import PlaceDropdown from '@components/userMain/PlaceDropdown';
 import styled from 'styled-components';
-import { useSelector } from 'react-redux';
-import { PathPoint } from '@custom-types';
+import { shallowEqual, useSelector } from 'react-redux';
+import { PathPoint, Location } from '@custom-types';
+import setStartToNearPlace from '@utils/setStartToNearPlace';
+import { useGoogleMapApiState } from 'src/contexts/GoogleMapProvider';
+import { useDispatch } from 'react-redux';
 
 const InputPlaces: React.FC = () => {
   const pathPoint = useSelector((state: { pathPoint: PathPoint }) => state.pathPoint);
+  const location = useSelector((state: { location: Location }) => state.location, shallowEqual);
+  const { maps } = useGoogleMapApiState();
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    if (maps && !pathPoint.isSetStartPoint) {
+      setStartToNearPlace(dispatch, location, maps);
+    }
+  }, [maps, location]);
+
   const Dropdown = () => {
     return (
       <>

--- a/client/src/components/userSignup/InputPhoneNum.tsx
+++ b/client/src/components/userSignup/InputPhoneNum.tsx
@@ -42,8 +42,4 @@ const Div = styled.div`
   margin-bottom: 20px;
 `;
 
-const H3 = styled.h3`
-  font-size: 18px;
-`;
-
 export default InputPhoneNum;

--- a/client/src/containers/MapContainer.tsx
+++ b/client/src/containers/MapContainer.tsx
@@ -1,9 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import Map from '@components/map/Map';
 import Loading from '@components/common/Loading';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector, useDispatch, shallowEqual } from 'react-redux';
 import { updateLocation } from '@stores/modules/location';
-import { updateStartPoint } from '@stores/modules/pathPoint';
 import getLocation from '@utils/getLocation';
 import { Location, PathPoint } from '@custom-types';
 import { Toast } from 'antd-mobile';
@@ -15,7 +14,7 @@ interface Props {
 }
 
 const MapContainer: React.FC<Props> = ({ isMatched = false, taxiLocation = { lat: 0, lng: 0 } }) => {
-  const location = useSelector((state: { location: Location }) => state.location);
+  const location = useSelector((state: { location: Location }) => state.location, shallowEqual);
   const pathPoint = useSelector((state: { pathPoint: PathPoint }) => state.pathPoint);
   const dispatch = useDispatch();
   const [center, setCenter] = useState(location);
@@ -23,6 +22,8 @@ const MapContainer: React.FC<Props> = ({ isMatched = false, taxiLocation = { lat
 
   useEffect(() => {
     initializeLocation();
+    const gpsInterval = setInterval(updateMyLocation, 1000);
+    return () => clearInterval(gpsInterval);
   }, []);
 
   const initializeLocation = async () => {

--- a/client/src/containers/MapContainer.tsx
+++ b/client/src/containers/MapContainer.tsx
@@ -35,27 +35,6 @@ const MapContainer: React.FC<Props> = ({ isMatched = false, taxiLocation = { lat
     setGPSLoaded(true);
   };
 
-  const findNearPlace = (map: any) => {
-    if (pathPoint.isSetStartPoint) return;
-    const service = new google.maps.places.PlacesService(map);
-
-    const request = {
-      location: center,
-      type: 'store',
-      rankBy: google.maps.places.RankBy.DISTANCE,
-    };
-
-    service.nearbySearch(request, (results, status) => {
-      const result = results && results[0];
-      if (status === google.maps.places.PlacesServiceStatus.OK && result) {
-        const { geometry, name, place_id } = result;
-        dispatch(
-          updateStartPoint({ lat: geometry?.location.lat() || 0, lng: geometry?.location.lng() || 0 }, name, place_id),
-        );
-      }
-    });
-  };
-
   const updateMyLocation = async () => {
     try {
       const myLocation: Location = await getLocation();
@@ -73,10 +52,8 @@ const MapContainer: React.FC<Props> = ({ isMatched = false, taxiLocation = { lat
           center={center}
           location={location}
           pathPoint={pathPoint}
-          updateMyLocation={updateMyLocation}
           isMatched={isMatched}
           taxiLocation={taxiLocation}
-          findNearPlace={findNearPlace}
         />
       ) : (
         <CenterDIV>

--- a/client/src/containers/MapContainer.tsx
+++ b/client/src/containers/MapContainer.tsx
@@ -12,16 +12,14 @@ import styled from 'styled-components';
 interface Props {
   isMatched?: boolean;
   taxiLocation?: Location;
-  directionRenderer?: any;
 }
 
-const MapContainer: React.FC<Props> = ({ isMatched = false, taxiLocation = { lat: 0, lng: 0 }, directionRenderer }) => {
+const MapContainer: React.FC<Props> = ({ isMatched = false, taxiLocation = { lat: 0, lng: 0 } }) => {
   const location = useSelector((state: { location: Location }) => state.location);
   const pathPoint = useSelector((state: { pathPoint: PathPoint }) => state.pathPoint);
   const dispatch = useDispatch();
   const [center, setCenter] = useState(location);
   const [isGPSLoaded, setGPSLoaded] = useState(false);
-  // const [isSetNearPlace, setNearPlace] = useState(false);
 
   useEffect(() => {
     initializeLocation();
@@ -38,9 +36,6 @@ const MapContainer: React.FC<Props> = ({ isMatched = false, taxiLocation = { lat
 
   const findNearPlace = (map: any) => {
     if (pathPoint.isSetStartPoint) return;
-    // if (isSetNearPlace) return;
-    // setNearPlace(true);
-
     const service = new google.maps.places.PlacesService(map);
 
     const request = {
@@ -77,11 +72,9 @@ const MapContainer: React.FC<Props> = ({ isMatched = false, taxiLocation = { lat
           center={center}
           location={location}
           pathPoint={pathPoint}
-          zoom={16}
           updateMyLocation={updateMyLocation}
           isMatched={isMatched}
           taxiLocation={taxiLocation}
-          directionRenderer={directionRenderer}
           findNearPlace={findNearPlace}
         />
       ) : (

--- a/client/src/contexts/GoogleMapProvider.tsx
+++ b/client/src/contexts/GoogleMapProvider.tsx
@@ -4,9 +4,20 @@ import { Loader } from '@googlemaps/js-api-loader';
 interface State {
   loaded: boolean;
   directionRenderer: google.maps.DirectionsRenderer | null;
+  maps?: any;
 }
 
-type Action = { type: 'updateApiState'; loaded: boolean; directionRenderer: google.maps.DirectionsRenderer };
+type Action =
+  | {
+      type: 'updateApiState';
+      loaded: boolean;
+      directionRenderer: google.maps.DirectionsRenderer;
+      maps?: any;
+    }
+  | {
+      type: 'setMaps';
+      maps: any;
+    };
 
 type IDispatch = Dispatch<Action>;
 
@@ -18,7 +29,9 @@ const loader = new Loader({
 const reducer = (state: State, action: Action): State => {
   switch (action.type) {
     case 'updateApiState':
-      return { ...state, loaded: action.loaded, directionRenderer: action.directionRenderer };
+      return { ...state, loaded: action.loaded, directionRenderer: action.directionRenderer, maps: action.maps };
+    case 'setMaps':
+      return { ...state, maps: action.maps };
     default:
       throw new Error(`Wrong action`);
   }
@@ -27,7 +40,7 @@ const reducer = (state: State, action: Action): State => {
 export const GoogleMapApiState = React.createContext<State | null>(null);
 export const GoogleMapApiDispatch = React.createContext<IDispatch | null>(null);
 
-const initialState = { loaded: false, directionRenderer: null };
+const initialState = { loaded: false, directionRenderer: null, maps: null };
 
 const GoogleMapProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [state, dispatch] = useReducer(reducer, initialState);

--- a/client/src/contexts/GoogleMapProvider.tsx
+++ b/client/src/contexts/GoogleMapProvider.tsx
@@ -3,10 +3,10 @@ import { Loader } from '@googlemaps/js-api-loader';
 
 interface State {
   loaded: boolean;
-  directionRenderer: any;
+  directionRenderer: google.maps.DirectionsRenderer | null;
 }
 
-type Action = { type: 'updateApiState'; loaded: boolean; directionRenderer: any };
+type Action = { type: 'updateApiState'; loaded: boolean; directionRenderer: google.maps.DirectionsRenderer };
 
 type IDispatch = Dispatch<Action>;
 

--- a/client/src/contexts/GoogleMapProvider.tsx
+++ b/client/src/contexts/GoogleMapProvider.tsx
@@ -1,0 +1,66 @@
+import React, { useEffect, useReducer, Dispatch, useContext } from 'react';
+import { Loader } from '@googlemaps/js-api-loader';
+
+interface State {
+  loaded: boolean;
+  directionRenderer: any;
+}
+
+type Action = { type: 'updateApiState'; loaded: boolean; directionRenderer: any };
+
+type IDispatch = Dispatch<Action>;
+
+const loader = new Loader({
+  apiKey: process.env.REACT_APP_GOOGLE_MAP_API_KEY || '',
+  libraries: ['places'],
+});
+
+const reducer = (state: State, action: Action): State => {
+  switch (action.type) {
+    case 'updateApiState':
+      return { ...state, loaded: action.loaded, directionRenderer: action.directionRenderer };
+    default:
+      throw new Error(`Wrong action`);
+  }
+};
+
+export const GoogleMapApiState = React.createContext<State | null>(null);
+export const GoogleMapApiDispatch = React.createContext<IDispatch | null>(null);
+
+const initialState = { loaded: false, directionRenderer: null };
+
+const GoogleMapProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const initialScriptLoad = async () => {
+    await loader.load();
+    dispatch({
+      type: 'updateApiState',
+      loaded: true,
+      directionRenderer: new google.maps.DirectionsRenderer({ suppressMarkers: true }),
+    });
+  };
+
+  useEffect(() => {
+    initialScriptLoad();
+  }, []);
+
+  return (
+    <GoogleMapApiState.Provider value={state}>
+      <GoogleMapApiDispatch.Provider value={dispatch}>{children}</GoogleMapApiDispatch.Provider>
+    </GoogleMapApiState.Provider>
+  );
+};
+
+export function useGoogleMapApiState(): State {
+  const state = useContext(GoogleMapApiState);
+  if (!state) throw new Error('Cannot find GoogleMapApiProvider');
+  return state;
+}
+
+export function useGoogleMapApiDispatch(): IDispatch {
+  const dispatch = useContext(GoogleMapApiDispatch);
+  if (!dispatch) throw new Error('Cannot find GoogleMapApiProvider');
+  return dispatch;
+}
+
+export default GoogleMapProvider;

--- a/client/src/pages/driver/DriverMatchingPage.tsx
+++ b/client/src/pages/driver/DriverMatchingPage.tsx
@@ -3,7 +3,6 @@ import { useDispatch } from 'react-redux';
 import { useMutation } from '@apollo/client';
 import { updateStartPoint, updateEndPoint } from '@stores/modules/pathPoint';
 import { gql, useSubscription } from '@apollo/client';
-import { Loader } from '@googlemaps/js-api-loader';
 import { USER_ON_BOARD } from '@queries/driver/driverMatching';
 import MapContainer from '@containers/MapContainer';
 import CallButton from '@components/common/CallButton';
@@ -12,11 +11,7 @@ import styled from 'styled-components';
 import { Button, Toast } from 'antd-mobile';
 import { Response } from '@custom-types';
 import PaymentModal from '@components/driverMap/PaymentModal';
-
-const loader = new Loader({
-  apiKey: process.env.REACT_APP_GOOGLE_MAP_API_KEY || '',
-  libraries: ['places'],
-});
+import { useGoogleMapApiState } from 'src/contexts/GoogleMapProvider';
 
 const MATCHED_USER = gql`
   subscription {
@@ -33,9 +28,9 @@ const MATCHED_USER = gql`
 const DriverMatchingPage: React.FC = () => {
   const dispatch = useDispatch();
   const { data, error } = useSubscription(MATCHED_USER);
-  const [googleMapApi, setGoogleMapApi]: any = useState({ loaded: false, directionRenderer: null });
   const [boarding, setBoarding] = useState(false);
   const [visible, setVisible] = useState(false);
+  const { loaded } = useGoogleMapApiState();
 
   const arrive = () => {
     setVisible(true);
@@ -56,16 +51,6 @@ const DriverMatchingPage: React.FC = () => {
     startLocation: { name: '', Latlng: { lat: '', lng: '' } },
     endLocation: { name: '', Latlng: { lat: '', lng: '' } },
   });
-
-  const initialScriptLoad = async () => {
-    await loader.load();
-    setGoogleMapApi({ loaded: true, directionRenderer: new google.maps.DirectionsRenderer() });
-  };
-
-  useEffect(() => {
-    initialScriptLoad();
-  }, []);
-
   useEffect(() => {
     if (data?.driverServiceSub) {
       const requsetData = data.userMatchingSub;
@@ -82,9 +67,9 @@ const DriverMatchingPage: React.FC = () => {
 
   return (
     <>
-      {googleMapApi.loaded && (
+      {loaded && (
         <>
-          <MapContainer directionRenderer={googleMapApi.directionRenderer} />
+          <MapContainer />
           {boarding ? (
             <>
               <PaymentModal visible={visible} />

--- a/client/src/pages/user/UserMainPage.tsx
+++ b/client/src/pages/user/UserMainPage.tsx
@@ -1,36 +1,21 @@
-import React, { useState, useEffect } from 'react';
-import { Loader } from '@googlemaps/js-api-loader';
+import React from 'react';
 import MapContainer from '@containers/MapContainer';
 import InputPlaces from '@components/userMain/InputPlaces';
 import PreReqData from '@components/userMain/PreReqData';
 import { PreData } from '@custom-types';
 import { useSelector } from 'react-redux';
-
-const loader = new Loader({
-  apiKey: process.env.REACT_APP_GOOGLE_MAP_API_KEY || '',
-  libraries: ['places'],
-});
+import { useGoogleMapApiState } from 'src/contexts/GoogleMapProvider';
 
 const UserMainPage: React.FC = () => {
   const preData = useSelector((state: { preData: PreData }) => state.preData);
-  const [googleMapApi, setGoogleMapApi]: any = useState({ loaded: false, directionRenderer: null });
+  const { loaded } = useGoogleMapApiState();
   const info = preData.info;
-
-  const initialScriptLoad = async () => {
-    await loader.load();
-    setGoogleMapApi({ loaded: true, directionRenderer: new google.maps.DirectionsRenderer({ suppressMarkers: true }) });
-  };
-
-  useEffect(() => {
-    initialScriptLoad();
-  }, []);
-
   return (
     <>
-      {googleMapApi.loaded && (
+      {loaded && (
         <>
           <InputPlaces />
-          <MapContainer directionRenderer={googleMapApi.directionRenderer} />
+          <MapContainer />
           {preData.isSetPath && <PreReqData time={info.time} fee={info.fee} />}
         </>
       )}

--- a/client/src/pages/user/UserMatchingPage.tsx
+++ b/client/src/pages/user/UserMatchingPage.tsx
@@ -8,7 +8,7 @@ import { useHistory } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { PathPoint } from '@custom-types';
 import MatchingWrapper from '@components/userMatching/MatchingWrapper';
-import Path from '@components/userMatching/RequestInfo';
+import RequestInfo from '@components/userMatching/RequestInfo';
 
 const MAX_REQUEST_COUNT = 6;
 const MATCHING_INTERVAL = 10000;
@@ -170,7 +170,7 @@ const UserMatchingPage: React.FC = () => {
     <>
       {googleMapApi.loaded && (
         <>
-          <Path startPoint={pathPoint.startPointName || ''} endPoint={pathPoint.endPointName || ''} />
+          <RequestInfo startPoint={pathPoint.startPointName || ''} endPoint={pathPoint.endPointName || ''} />
           {loading && <MatchingWrapper onClickHandler={onClickHandler} />}
           {data && onMatchSuccess()}
           <MapContainer

--- a/client/src/pages/user/UserMatchingPage.tsx
+++ b/client/src/pages/user/UserMatchingPage.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
 import { gql, useSubscription, useMutation } from '@apollo/client';
-import { Loader } from '@googlemaps/js-api-loader';
 import MatchedDriverData from '@components/userMatching/MatchedDriverData';
 import MapContainer from '@containers/MapContainer';
 import { Toast } from 'antd-mobile';
@@ -9,14 +8,10 @@ import { useSelector } from 'react-redux';
 import { PathPoint } from '@custom-types';
 import MatchingWrapper from '@components/userMatching/MatchingWrapper';
 import RequestInfo from '@components/userMatching/RequestInfo';
+import { useGoogleMapApiState } from 'src/contexts/GoogleMapProvider';
 
 const MAX_REQUEST_COUNT = 6;
 const MATCHING_INTERVAL = 10000;
-
-const loader = new Loader({
-  apiKey: process.env.REACT_APP_GOOGLE_MAP_API_KEY || '',
-  libraries: ['places'],
-});
 
 const MATCHED_TAXI = gql`
   subscription {
@@ -51,16 +46,10 @@ const UserMatchingPage: React.FC = () => {
   const [isMatched, setMatchState] = useState(false);
   const [taxiInfo, setTaxiInfo] = useState({ id: '', name: '', carModel: '', carColor: '', plateNumber: '' });
   const [taxiLocation, setTaxiLocation] = useState(undefined);
-  const [googleMapApi, setGoogleMapApi]: any = useState({ loaded: false, directionRenderer: null });
   const [isMatchCanceled, setMatchCancel] = useState(false);
-
-  const initialScriptLoad = async () => {
-    await loader.load();
-    setGoogleMapApi({ loaded: true, directionRenderer: new google.maps.DirectionsRenderer({ suppressMarkers: true }) });
-  };
+  const { loaded } = useGoogleMapApiState();
 
   useEffect(() => {
-    initialScriptLoad();
     (async () => await registMatchingList())();
   }, []);
 
@@ -168,16 +157,12 @@ const UserMatchingPage: React.FC = () => {
 
   return (
     <>
-      {googleMapApi.loaded && (
+      {loaded && (
         <>
           <RequestInfo startPoint={pathPoint.startPointName || ''} endPoint={pathPoint.endPointName || ''} />
           {loading && <MatchingWrapper onClickHandler={onClickHandler} />}
           {data && onMatchSuccess()}
-          <MapContainer
-            isMatched={isMatched}
-            taxiLocation={taxiLocation}
-            directionRenderer={googleMapApi.directionRenderer}
-          />
+          <MapContainer isMatched={isMatched} taxiLocation={taxiLocation} />
           {isMatched && <MatchedDriverData taxiInfo={taxiInfo} />}
         </>
       )}

--- a/client/src/stories/MatchingCancelBtn.stories.tsx
+++ b/client/src/stories/MatchingCancelBtn.stories.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import { Meta } from '@storybook/react/types-6-0';
-import { text } from '@storybook/addon-knobs';
-
 import Btn from '../components/userMatching/MatchingCancelButton';
 
 export default {

--- a/client/src/utils/setStartToNearPlace.tsx
+++ b/client/src/utils/setStartToNearPlace.tsx
@@ -1,0 +1,25 @@
+import { Location } from '@custom-types';
+import { updateStartPoint } from '@stores/modules/pathPoint';
+import { Dispatch } from 'react';
+
+const setStartToNearPlace = (dispatch: Dispatch<any>, location: Location, map: any): void => {
+  const service = new google.maps.places.PlacesService(map);
+
+  const request = {
+    location: location,
+    type: 'store',
+    rankBy: google.maps.places.RankBy.DISTANCE,
+  };
+
+  service.nearbySearch(request, (results, status) => {
+    const result = results && results[0];
+    if (status === google.maps.places.PlacesServiceStatus.OK && result) {
+      const { geometry, name, place_id } = result;
+      dispatch(
+        updateStartPoint({ lat: geometry?.location.lat() || 0, lng: geometry?.location.lng() || 0 }, name, place_id),
+      );
+    }
+  });
+};
+
+export default setStartToNearPlace;


### PR DESCRIPTION
## 해당 이슈 📎

#95 리팩토링 진행 시 관련 이슈가 없어 임의로 작성한 이슈입니다.

## 변경 사항 🛠

- GoogleApi 관련 로직을 context로 묶어서 한곳에서 load하고 사용할 수 있도록 변경
- 1초마다 현재 위치를 받아와 스토어에 업데이트 하는 것을 `Map.tsx` → `MapContainer.tsx`로 이동
- `useSelector`에 `shallowEqual`을 이용해 location의 값이 변하지 않았다면 재렌더링 되지 않도록 수정
- 현재 위치의 가장 가까운 가게를 자동으로 시작지점으로 지정하는 로직을 `MapContainer.tsx`에서 `InputPlaces.tsx`로 이동
- `InputPlaces`도 `shallowEqual`을 이용해 location 변경시 재 랜더링 되던점 수정

## 테스트 ✨

없음

## 리뷰어 참고 사항 🙋‍♀️

- 커밋 단위가 큽니다 🙇 이해가 안되는 부분은 바로바로 질문해주세요!
