### PR TITLE
유저 이용내역 페이지 및 컴포넌트 제작

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -56,6 +56,7 @@
     "jest-resolve": "26.6.0",
     "jest-watch-typeahead": "0.6.1",
     "mini-css-extract-plugin": "0.11.3",
+    "moment": "^2.29.1",
     "optimize-css-assets-webpack-plugin": "5.0.4",
     "pnp-webpack-plugin": "1.6.4",
     "postcss-flexbugs-fixes": "4.2.1",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -10,6 +10,7 @@ import {
   UserMatchingPage,
   UserSigninPage,
   UserSignupPage,
+  UserHistoryPage,
   DriverAuthPage,
   DriverMainPage,
   DriverMatchingPage,
@@ -46,6 +47,7 @@ const App: React.FC = () => {
               <AuthRouter path="/user/signin" component={UserSigninPage} />
               <UserRouter path="/user/map" component={UserMainPage} />
               <UserRouter path="/user/matching" component={UserMatchingPage} />
+              <UserRouter path="/user/history" component={UserHistoryPage} />
               <AuthRouter exact path="/driver" component={DriverAuthPage} />
               <AuthRouter path="/driver/signup" component={DriverSignupPage} />
               <AuthRouter path="/driver/signin" component={DriverSigninPage} />

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { ApolloProvider } from '@apollo/client';
 import { BrowserRouter, Switch, Route } from 'react-router-dom';
 import client from '@utils/apolloClient';
-import 'antd-mobile/lib/button/style/css';
 import {
   UserDriverSelectPage,
   UserAuthPage,
@@ -31,6 +30,8 @@ import 'antd-mobile/lib/input-item/style/css';
 import 'antd-mobile/lib/toast/style/css';
 import 'antd-mobile/lib/modal/style/css';
 import 'antd-mobile/lib/activity-indicator/style/css';
+import 'antd-mobile/lib/card/style/css';
+import 'antd-mobile/lib/white-space/style/css';
 import 'antd/lib/switch/style/css';
 import 'antd/lib/progress/style/css';
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -31,9 +31,9 @@ import 'antd-mobile/lib/toast/style/css';
 import 'antd-mobile/lib/modal/style/css';
 import 'antd-mobile/lib/activity-indicator/style/css';
 import 'antd-mobile/lib/card/style/css';
-import 'antd-mobile/lib/white-space/style/css';
 import 'antd/lib/switch/style/css';
 import 'antd/lib/progress/style/css';
+import 'antd/lib/button/style/css';
 
 const App: React.FC = () => {
   return (

--- a/client/src/components/map/Map.tsx
+++ b/client/src/components/map/Map.tsx
@@ -5,7 +5,7 @@ import TaxiMarker from '@components/common/TaxiMarker';
 import { Location, PathPoint } from '@custom-types';
 import { updatePath } from '@stores/modules/preData';
 import { useDispatch } from 'react-redux';
-import { useGoogleMapApiState, useGoogleMapApiDispatch } from 'src/contexts/GoogleMapProvider';
+import { useGoogleMapApiState, useGoogleMapApiDispatch } from '../../contexts/GoogleMapProvider';
 
 const Map: React.FC<{
   center: Location;

--- a/client/src/components/userHistory/HistoryBox.tsx
+++ b/client/src/components/userHistory/HistoryBox.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import moment from 'moment';
-import { Card, WhiteSpace, List } from 'antd-mobile';
+import { Card, List } from 'antd-mobile';
 import { LocationWithName } from '@custom-types';
 import styled from 'styled-components';
 
@@ -20,10 +20,10 @@ const HistoryBox: React.FC<HistoryType> = ({
       <Card full>
         <Card.Body>
           <List renderHeader={() => moment(startTime).format('YYYY/MM/DD')}>
-            <Item extra={startLocation} wrap>
+            <Item extra={startLocation.name} wrap>
               출발
             </Item>
-            <Item extra={endLocation} wrap>
+            <Item extra={endLocation.name} wrap>
               도착
             </Item>
             <Item extra={`${moment(startTime).format('HH:mm')} - ${moment(endTime).format('HH:mm')}`} wrap>
@@ -36,7 +36,6 @@ const HistoryBox: React.FC<HistoryType> = ({
           </List>
         </Card.Body>
       </Card>
-      <WhiteSpace size="lg" />
     </Wrapper>
   );
 };

--- a/client/src/components/userHistory/HistoryBox.tsx
+++ b/client/src/components/userHistory/HistoryBox.tsx
@@ -3,9 +3,6 @@ import moment from 'moment';
 import { Card, WhiteSpace, List } from 'antd-mobile';
 import { LocationWithName } from '@custom-types';
 import styled from 'styled-components';
-import 'antd-mobile/lib/card/style/css';
-import 'antd-mobile/lib/white-space/style/css';
-import 'antd-mobile/lib/list/style/css';
 
 const Item = List.Item;
 

--- a/client/src/components/userHistory/HistoryBox.tsx
+++ b/client/src/components/userHistory/HistoryBox.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import moment from 'moment';
+import { Card, WhiteSpace, List } from 'antd-mobile';
+import { LocationWithName } from '@custom-types';
+import styled from 'styled-components';
+import 'antd-mobile/lib/card/style/css';
+import 'antd-mobile/lib/white-space/style/css';
+import 'antd-mobile/lib/list/style/css';
+
+const Item = List.Item;
+
+const HistoryBox: React.FC<HistoryType> = ({
+  startLocation,
+  endLocation,
+  startTime,
+  endTime,
+  fee,
+  carModel,
+  plateNumber,
+}) => {
+  return (
+    <Wrapper>
+      <Card full>
+        <Card.Body>
+          <List renderHeader={() => moment(startTime).format('YYYY/MM/DD')}>
+            <Item extra={startLocation} wrap>
+              출발
+            </Item>
+            <Item extra={endLocation} wrap>
+              도착
+            </Item>
+            <Item extra={`${moment(startTime).format('HH:mm')} - ${moment(endTime).format('HH:mm')}`} wrap>
+              운행 시간
+            </Item>
+            <Item extra={`${fee}원`}>요금</Item>
+            <Item extra={`${carModel} | ${plateNumber}`} wrap>
+              택시 정보
+            </Item>
+          </List>
+        </Card.Body>
+      </Card>
+      <WhiteSpace size="lg" />
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled.div`
+  .am-card-body {
+    padding: 6px 15px;
+  }
+  .am-list-item {
+    min-height: 0.8rem !important;
+    div {
+      font-size: 0.9rem !important;
+      border-bottom: none !important;
+    }
+    .am-list-content {
+      flex: 1 0 !important;
+      color: gray;
+    }
+    .am-list-extra {
+      flex: 2 1 !important;
+      color: black;
+      text-align: left;
+    }
+  }
+`;
+
+interface HistoryType {
+  startLocation: LocationWithName;
+  endLocation: LocationWithName;
+  startTime: Date;
+  endTime: Date;
+  fee: number;
+  carModel: string;
+  plateNumber: string;
+}
+
+export default HistoryBox;

--- a/client/src/components/userHistory/HistoryBox.tsx
+++ b/client/src/components/userHistory/HistoryBox.tsx
@@ -42,11 +42,12 @@ const HistoryBox: React.FC<HistoryType> = ({
 
 const Wrapper = styled.div`
   .am-card-body {
-    padding: 6px 15px;
+    padding: 0 15px;
   }
   .am-list-item {
-    min-height: 0.8rem !important;
+    min-height: 0.6rem !important;
     div {
+      padding: 0.1rem !important;
       font-size: 0.9rem !important;
       border-bottom: none !important;
     }

--- a/client/src/components/userHistory/HistoryBox.tsx
+++ b/client/src/components/userHistory/HistoryBox.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import moment from 'moment';
 import { Card, List } from 'antd-mobile';
 import { LocationWithName } from '@custom-types';
@@ -15,11 +15,13 @@ const HistoryBox: React.FC<HistoryType> = ({
   carModel,
   plateNumber,
 }) => {
+  const formatStartDate = useCallback(() => moment(startTime).format('YYYY/MM/DD'), [startTime]);
+
   return (
     <Wrapper>
       <Card full>
         <Card.Body>
-          <List renderHeader={() => moment(startTime).format('YYYY/MM/DD')}>
+          <List renderHeader={formatStartDate}>
             <Item extra={startLocation.name} wrap>
               출발
             </Item>

--- a/client/src/pages/index.ts
+++ b/client/src/pages/index.ts
@@ -4,6 +4,7 @@ export { default as UserMainPage } from './user/UserMainPage';
 export { default as UserMatchingPage } from './user/UserMatchingPage';
 export { default as UserSigninPage } from './user/UserSigninPage';
 export { default as UserSignupPage } from './user/UserSignupPage';
+export { default as UserHistoryPage } from './user/UserHistoryPage';
 export { default as DriverAuthPage } from './driver/DriverAuthPage';
 export { default as DriverMainPage } from './driver/DriverMainPage';
 export { default as DriverMatchingPage } from './driver/DriverMatchingPage';

--- a/client/src/pages/user/UserHistoryPage.tsx
+++ b/client/src/pages/user/UserHistoryPage.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const UserHistoryPage: React.FC = () => {
+  return <div>유저 히스토리 페이지</div>;
+};
+
+export default UserHistoryPage;

--- a/client/src/pages/user/UserHistoryPage.tsx
+++ b/client/src/pages/user/UserHistoryPage.tsx
@@ -1,7 +1,46 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { useHistory } from 'react-router-dom';
+import { useQuery } from '@apollo/client';
+import HistoryBox from '@components/userHistory/HistoryBox';
+import { GET_USER_HISTORY } from '@queries/user/userHistory';
+import styled from 'styled-components';
+import { Button } from 'antd';
+import { HomeFilled } from '@ant-design/icons';
 
 const UserHistoryPage: React.FC = () => {
-  return <div>유저 히스토리 페이지</div>;
+  const history = useHistory();
+  const [page, setPage] = useState(1);
+  const { loading, data } = useQuery(GET_USER_HISTORY, { variables: { page } });
+
+  if (loading || !data) return <>로딩중</>;
+  return (
+    <Wrapper>
+      <Title>택시자버 이용내역</Title>
+      {data.userHistory.map(({ id, request, ...info }: any) => (
+        <HistoryBox key={id} {...request} {...info} />
+      ))}
+      <Button
+        shape="circle"
+        icon={<HomeFilled />}
+        size="large"
+        type="primary"
+        style={{ position: 'fixed', bottom: '0', right: '0', margin: '25px' }}
+        onClick={() => {
+          history.push('/user/map');
+        }}
+      />
+    </Wrapper>
+  );
 };
+
+const Wrapper = styled.div`
+  position: absolute;
+  width: 100vw;
+  height: 100vh;
+`;
+
+const Title = styled.h1`
+  margin: 25px 0 10px 25px;
+`;
 
 export default UserHistoryPage;

--- a/client/src/pages/user/UserHistoryPage.tsx
+++ b/client/src/pages/user/UserHistoryPage.tsx
@@ -1,24 +1,66 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useQuery } from '@apollo/client';
 import HistoryBox from '@components/userHistory/HistoryBox';
 import { GET_USER_HISTORY } from '@queries/user/userHistory';
 import styled from 'styled-components';
 import { Button } from 'antd';
+import { ActivityIndicator } from 'antd-mobile';
 import { HomeFilled } from '@ant-design/icons';
+
+const RESULT_PER_PAGE = 10;
 
 const UserHistoryPage: React.FC = () => {
   const history = useHistory();
   const [page, setPage] = useState(1);
-  const { loading, data } = useQuery(GET_USER_HISTORY, { variables: { page } });
+  const [buttonDisabled, setButtonDisabled] = useState({ prev: true, next: false });
+  const [showingHistory, setShowingHistory] = useState([]);
+  const { loading, data } = useQuery(GET_USER_HISTORY, { variables: { page: page }, fetchPolicy: 'network-only' });
 
-  if (loading || !data) return <>로딩중</>;
+  const onPrev = useCallback(() => {
+    setPage(page - 1);
+    if (page === 2) setButtonDisabled({ prev: true, next: false });
+    else setButtonDisabled({ ...buttonDisabled, next: false });
+  }, [page, buttonDisabled]);
+
+  const onNext = useCallback(() => {
+    setPage(page + 1);
+    setButtonDisabled({ ...buttonDisabled, prev: false });
+  }, [page, buttonDisabled]);
+
+  useEffect(() => {
+    if (data?.userHistory.length) {
+      setShowingHistory(data.userHistory);
+      if (data.userHistory.length < RESULT_PER_PAGE) setButtonDisabled({ ...buttonDisabled, next: true });
+    } else if (data?.userHistory.length === 0) {
+      setPage(page - 1);
+      setButtonDisabled({ ...buttonDisabled, next: true });
+    }
+  }, [data]);
+
+  if (loading)
+    return (
+      <LoadingWrapper>
+        <ActivityIndicator animating text="로딩 중입니다" />
+      </LoadingWrapper>
+    );
+
   return (
     <Wrapper>
       <Title>택시자버 이용내역</Title>
-      {data.userHistory.map(({ id, request, ...info }: any) => (
-        <HistoryBox key={id} {...request} {...info} />
-      ))}
+      {showingHistory.length ? (
+        showingHistory.map(({ id, request, ...info }: any) => <HistoryBox key={id} {...request} {...info} />)
+      ) : (
+        <NoHistory>이용내역이 없습니다</NoHistory>
+      )}
+      <PaginationButtonGrup>
+        <Button disabled={buttonDisabled.prev} onClick={onPrev}>
+          최근내역
+        </Button>
+        <Button disabled={buttonDisabled.next} onClick={onNext}>
+          이전내역
+        </Button>
+      </PaginationButtonGrup>
       <Button
         shape="circle"
         icon={<HomeFilled />}
@@ -41,6 +83,32 @@ const Wrapper = styled.div`
 
 const Title = styled.h1`
   margin: 25px 0 10px 25px;
+`;
+
+const PaginationButtonGrup = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  padding: 20px 0 30px;
+
+  > button {
+    margin: 0 20px;
+  }
+`;
+
+const LoadingWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  width: 100vw;
+`;
+
+const NoHistory = styled.h2`
+  text-align: center;
+  padding: 50px 0;
 `;
 
 export default UserHistoryPage;

--- a/client/src/pages/user/UserHistoryPage.tsx
+++ b/client/src/pages/user/UserHistoryPage.tsx
@@ -38,12 +38,13 @@ const UserHistoryPage: React.FC = () => {
     }
   }, [data]);
 
-  if (loading)
+  if (loading) {
     return (
       <LoadingWrapper>
         <ActivityIndicator animating text="로딩 중입니다" />
       </LoadingWrapper>
     );
+  }
 
   return (
     <Wrapper>

--- a/client/src/queries/user/userHistory.ts
+++ b/client/src/queries/user/userHistory.ts
@@ -1,0 +1,22 @@
+import { gql } from '@apollo/client';
+
+export const GET_USER_HISTORY = gql`
+  query UserHistory($page: Int) {
+    userHistory(page: $page) {
+      id
+      request {
+        startLocation {
+          name
+        }
+        endLocation {
+          name
+        }
+      }
+      fee
+      startTime
+      endTime
+      carModel
+      plateNumber
+    }
+  }
+`;

--- a/client/src/stories/HistoryContainer.stories.tsx
+++ b/client/src/stories/HistoryContainer.stories.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Meta } from '@storybook/react/types-6-0';
+import { number, text, date } from '@storybook/addon-knobs';
+
+import HistoryBox from '../components/userHistory/HistoryBox';
+
+export default {
+  title: 'History/Box',
+  component: HistoryBox,
+} as Meta;
+
+export const Example = () => (
+  <HistoryBox
+    startLocation={text('출발지', '서울역')}
+    endLocation={text('도착지', '부산역')}
+    fee={number('금액', 5000)}
+    carModel={text('차종', '마이바흐')}
+    plateNumber={text('번호판', '서울 바 7777')}
+    startTime={date('출발일시', new Date('2020-12-07 17:00:00'))}
+    endTime={date('도착일시', new Date('2020-12-07 18:00:00'))}
+  />
+);

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -87,16 +87,15 @@ export interface Response {
   message: string;
 }
 
+export interface LocationWithName {
+  name: string;
+  latlng: Location;
+}
+
 export interface DriverMatchingInfo {
   uid?: string;
   request?: {
-    startLocation: {
-      name: string;
-      latlng: Location;
-    };
-    endLocation: {
-      name: string;
-      latlng: Location;
-    };
+    startLocation: LocationWithName;
+    endLocation: LocationWithName;
   };
 }

--- a/server/graphql/resolver/query.ts
+++ b/server/graphql/resolver/query.ts
@@ -1,6 +1,9 @@
 const Query = {
   isAuthorizedUser: () => true,
   isAuthorizedDriver: () => true,
+  userHistory: async (_, { page }, { dataSources, uid }) => {
+    // TODO: history 조회 결과 return
+  },
 };
 
 export default Query;

--- a/server/graphql/schema/index.graphql
+++ b/server/graphql/schema/index.graphql
@@ -44,6 +44,7 @@ type DriverStatus {
   board: Boolean
 }
 type UserHistoryResult {
+  id: String
   request: UserRequest
   fee: Int
   startTime: String

--- a/server/graphql/schema/index.graphql
+++ b/server/graphql/schema/index.graphql
@@ -7,6 +7,7 @@ type Query {
   users: String
   isAuthorizedUser: Boolean @auth(requires: USER)
   isAuthorizedDriver: Boolean @auth(requires: DRIVER)
+  userHistory(page: Int): [UserHistoryResult] @auth(requires: USER)
 }
 
 type Response {
@@ -41,6 +42,14 @@ type DriverStatus {
   lat: Float
   lng: Float
   board: Boolean
+}
+type UserHistoryResult {
+  request: UserRequest
+  fee: Int
+  startTime: String
+  endTime: String
+  carModel: String
+  plateNumber: String
 }
 
 input LatLngInput {


### PR DESCRIPTION
## 해당 이슈 📎

#103, #104

## 변경 사항 🛠

- 이용내역 페이지 추가
- 이용내역 컴포넌트 추가
- Query schema만 추가
- useQuery로 내역 조회(한 번에 10건씩)
- 페이지네이션 적용
- mock test 진행

## 테스트 ✨
|내역이 있을 경우 | 내역이 없을 경우|
| --- | --- |
|<img src='https://user-images.githubusercontent.com/34625313/101374976-3194ab80-38f2-11eb-9b49-5f1671b44fc4.gif' width='300px'>|<img src='https://user-images.githubusercontent.com/34625313/101374994-38232300-38f2-11eb-8a6a-7fffd5083a42.png' width='300px'>|


## 리뷰어 참고 사항 🙋‍♀️

- 팀원에게 하고 싶은 말
  - 조회 query를 schema에 추가했습니다. 페이지네이션을 위해 page를 변수로 전달합니다. resolver 구현하다가 변경점 생기면 말씀해주세요!
  - 페이지네이션을 위한 mongoose 참고자료
  https://pro-self-studier.tistory.com/61