### PR TITLE
유저 이용내역 저장 및 전송

### DIFF
--- a/server/graphql/resolver/mutation.ts
+++ b/server/graphql/resolver/mutation.ts
@@ -3,7 +3,6 @@ import jwt from 'jsonwebtoken';
 import mongoose from 'mongoose';
 import Config from '../../config';
 import { logger } from '../../config/winston';
-import driverSchema from '../../models/driverSchema';
 import { REQUEST_ADDED, USER_MATCHED, USER_ON_BOARD, UPDATE_LOCATION } from './subscriptionType';
 
 const Mutation = {

--- a/server/graphql/resolver/mutation.ts
+++ b/server/graphql/resolver/mutation.ts
@@ -208,6 +208,17 @@ const Mutation = {
       return { success: false, message: '오류가 발생했습니다' };
     }
   },
+  saveUserHistory: async (_, args, { dataSources, res }) => {
+    try {
+      const userHistoryShema = dataSources.model('UserHistory');
+      const newUserHistory = new userHistoryShema({ ...args });
+      await newUserHistory.save();
+      return { success: true };
+    } catch (err) {
+      logger.error(`SAVE USER HISTORY ERROR : ${err}`);
+      return { success: false, message: `유저 사용내역 저장에 실패했습니다 : ${err}` };
+    }
+  },
 };
 
 export default Mutation;

--- a/server/graphql/resolver/mutation.ts
+++ b/server/graphql/resolver/mutation.ts
@@ -210,7 +210,7 @@ const Mutation = {
   saveUserHistory: async (_, args, { dataSources, res }) => {
     try {
       const userHistoryShema = dataSources.model('UserHistory');
-      const newUserHistory = new userHistoryShema({ ...args });
+      const newUserHistory = new userHistoryShema({ user_id: args.uid, ...args });
       await newUserHistory.save();
       return { success: true };
     } catch (err) {

--- a/server/graphql/resolver/mutation.ts
+++ b/server/graphql/resolver/mutation.ts
@@ -229,10 +229,10 @@ const Mutation = {
       return { success: false, message: '오류가 발생했습니다' };
     }
   },
-  saveUserHistory: async (_, args, { dataSources, res }) => {
+  saveUserHistory: async (_, args, { dataSources, res, uid }) => {
     try {
       const userHistoryShema = dataSources.model('UserHistory');
-      const newUserHistory = new userHistoryShema({ user_id: args.uid, ...args });
+      const newUserHistory = new userHistoryShema({ user_id: uid, ...args });
       await newUserHistory.save();
       return { success: true };
     } catch (err) {

--- a/server/graphql/resolver/query.ts
+++ b/server/graphql/resolver/query.ts
@@ -2,8 +2,11 @@ const Query = {
   isAuthorizedUser: () => true,
   isAuthorizedDriver: () => true,
   userHistory: async (_, { page }, { dataSources, uid }) => {
-    // TODO: history 조회 결과 return
+    const UserHistory = await dataSources.model('UserHistory');
+    const userHistoryAll = await UserHistory.find({ user_id: uid });
+    const [firstDataIdx, endDataIdx] = [(page - 1) * 10, page * 10];
+    const userHistoryOnPage = userHistoryAll.slice(firstDataIdx, endDataIdx);
+    return userHistoryOnPage;
   },
 };
-
 export default Query;

--- a/server/graphql/schema/index.graphql
+++ b/server/graphql/schema/index.graphql
@@ -98,11 +98,9 @@ type Mutation {
   approveMatching(uid: String): Response @auth(requires: DRIVER)
   userOnBoard(uid: String): Response @auth(requires: DRIVER)
   saveUserHistory(
-    uid: String!
     request: UserRequestInput!
     fee: Int!
     startTime: String!
-    endTime: String!
     carModel: String!
     plateNumber: String!
   ): Response @auth(requires: USER)

--- a/server/graphql/schema/index.graphql
+++ b/server/graphql/schema/index.graphql
@@ -95,6 +95,15 @@ type Mutation {
   updateDriverLocation(location: LatLngInput, uid: String): Response @auth(requires: DRIVER)
   approveMatching(uid: String): Response @auth(requires: DRIVER)
   userOnBoard(uid: String): Response @auth(requires: DRIVER)
+  saveUserHistory(
+    uid: String!
+    request: UserRequestInput!
+    fee: Int!
+    startTime: String!
+    endTime: String!
+    carModel: String!
+    plateNumber: String!
+  ): Response @auth(requires: USER)
 }
 
 type Subscription {

--- a/server/models/index.ts
+++ b/server/models/index.ts
@@ -3,10 +3,12 @@ import userSchema from './userSchema';
 import driverSchema from './driverSchema';
 import waitingDriverSchema from './waitingDriverSchema';
 import requestingUserSchema from './requestingUserSchema';
+import userHistorySchema from './userHistorySchema';
 
 mongoose.model('User', new mongoose.Schema(userSchema));
 mongoose.model('Driver', new mongoose.Schema(driverSchema));
 mongoose.model('WaitingDriver', new mongoose.Schema(waitingDriverSchema));
 mongoose.model('RequestingUser', new mongoose.Schema(requestingUserSchema));
+mongoose.model('UserHistory', new mongoose.Schema(userHistorySchema));
 
 export default mongoose;

--- a/server/models/locationSchema.ts
+++ b/server/models/locationSchema.ts
@@ -1,0 +1,11 @@
+import mongoose from 'mongoose';
+
+const locationSchema = new mongoose.Schema({
+  name: { type: String, default: 'Undefined Location Name' },
+  latlng: {
+    lat: { type: Number, required: true },
+    lng: { type: Number, required: true },
+  },
+});
+
+export default locationSchema;

--- a/server/models/requestLocationsShema.ts
+++ b/server/models/requestLocationsShema.ts
@@ -1,0 +1,9 @@
+import mongoose from 'mongoose';
+import locationSchema from './locationSchema';
+
+const requestLocations = new mongoose.Schema({
+  startLocation: locationSchema,
+  endLocation: locationSchema,
+});
+
+export default requestLocations;

--- a/server/models/userHistorySchema.ts
+++ b/server/models/userHistorySchema.ts
@@ -1,11 +1,12 @@
 import mongoose from 'mongoose';
 import requestLocationsShema from './requestLocationsShema';
+mongoose.set('useCreateIndex', true);
+
 const userHistorySchema = new mongoose.Schema({
-  user_id: { type: String, required: true, trim: true },
+  user_id: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
   request: requestLocationsShema,
   fee: { type: Number, required: true, trim: true },
   startTime: { type: String, required: true, trim: true },
-  endTime: { type: String, required: true, trim: true },
   carModel: { type: String, required: true, trim: true },
   plateNumber: { type: String, required: true, trim: true },
 });

--- a/server/models/userHistorySchema.ts
+++ b/server/models/userHistorySchema.ts
@@ -1,7 +1,7 @@
 import mongoose from 'mongoose';
 import requestLocationsShema from './requestLocationsShema';
 const userHistorySchema = new mongoose.Schema({
-  user_id: mongoose.Schema.Types.ObjectId,
+  user_id: { type: String, required: true, trim: true },
   request: requestLocationsShema,
   fee: { type: Number, required: true, trim: true },
   startTime: { type: String, required: true, trim: true },

--- a/server/models/userHistorySchema.ts
+++ b/server/models/userHistorySchema.ts
@@ -1,0 +1,13 @@
+import mongoose from 'mongoose';
+import requestLocationsShema from './requestLocationsShema';
+const userHistorySchema = new mongoose.Schema({
+  user_id: mongoose.Schema.Types.ObjectId,
+  request: requestLocationsShema,
+  fee: { type: Number, required: true, trim: true },
+  startTime: { type: String, required: true, trim: true },
+  endTime: { type: String, required: true, trim: true },
+  carModel: { type: String, required: true, trim: true },
+  plateNumber: { type: String, required: true, trim: true },
+});
+
+export default userHistorySchema;

--- a/server/models/waitingDriverSchema.ts
+++ b/server/models/waitingDriverSchema.ts
@@ -1,5 +1,6 @@
 import mongoose from 'mongoose';
 import pointSchema from './pointSchema';
+mongoose.set('useCreateIndex', true);
 
 const waitingDriver = new mongoose.Schema({
   driver: { type: mongoose.Schema.Types.ObjectId, ref: 'Driver' },


### PR DESCRIPTION
## 해당 이슈 📎

DB에 해당 유저의 이용내역 저장 #108
서버에서 해당 유저의 내역 전송 #118

## 변경 사항 🛠

- 사용자의 택시자버 이용 내역 데이터를 DB에 저장 합니다.
- 사용자의 택시자버 이용 내역 전체 데이터를 서버에서 전송 합니다.

## 테스트 ✨
![ezgif com-gif-maker (8)](https://user-images.githubusercontent.com/45927473/101569419-cc3ada80-3a17-11eb-991b-ab6ee764828e.gif)


## 리뷰어 참고 사항 🙋‍♀️

