### PR TITLE
드라이버가 메인 페이지 진입할 시 영업중인지 확인하게 변경

### DIFF
--- a/client/src/components/driverMain/DriverMainBody.tsx
+++ b/client/src/components/driverMain/DriverMainBody.tsx
@@ -7,7 +7,7 @@ import { START_SERVICE, STOP_SERVICE, UPDATE_LOCATION } from '@queries/driver/dr
 import { ActivityIndicator, Toast } from 'antd-mobile';
 import DriverWorkingContent from './DriverWorkingContent';
 
-const DriverMainBody: React.FC<{ isWorking: boolean }> = ({ isWorking }) => {
+const DriverMainBody: React.FC<{ isWaiting: boolean }> = ({ isWaiting }) => {
   const history = useHistory();
   const [updateDriverLocation] = useMutation(UPDATE_LOCATION);
   const [startService, { loading: updateStartServiceLoading, error: updateStartServiceError }] = useMutation(
@@ -23,7 +23,7 @@ const DriverMainBody: React.FC<{ isWorking: boolean }> = ({ isWorking }) => {
   }, [updateStartServiceError, updateStopServiceError]);
 
   useEffect(() => {
-    if (isWorking) {
+    if (isWaiting) {
       startService();
       const updateLocation = setInterval(async () => {
         const location = await getLocation();
@@ -40,12 +40,12 @@ const DriverMainBody: React.FC<{ isWorking: boolean }> = ({ isWorking }) => {
         })();
       };
     }
-  }, [isWorking]);
+  }, [isWaiting]);
 
   return (
     <Wrapper>
       {(updateStartServiceLoading || updateStopServiceLoading) && <ActivityIndicator toast text="로딩중..." />}
-      <>{isWorking ? <DriverWorkingContent /> : <WorkingFinished>영업종료</WorkingFinished>}</>
+      <>{isWaiting ? <DriverWorkingContent /> : <WorkingFinished>영업종료</WorkingFinished>}</>
     </Wrapper>
   );
 };

--- a/client/src/components/driverMain/WorkingToggle.tsx
+++ b/client/src/components/driverMain/WorkingToggle.tsx
@@ -2,10 +2,14 @@ import React from 'react';
 import { Switch } from 'antd';
 import styled from 'styled-components';
 
-const WorkingToggle: React.FC<{ onChange: (checked: boolean, event: Event) => void }> = ({ onChange }) => {
+const WorkingToggle: React.FC<{ onChange: (checked: boolean, event: Event) => void; checked: boolean }> = ({
+  onChange,
+  checked,
+}) => {
   return (
     <Wrapper>
       <Switch
+        checked={checked}
         onChange={onChange}
         style={{ height: '70px', width: '85%', borderRadius: '20px' }}
         checkedChildren="영업 종료하기"

--- a/client/src/pages/driver/DriverMainPage.tsx
+++ b/client/src/pages/driver/DriverMainPage.tsx
@@ -9,18 +9,18 @@ import Loading from '@components/common/Loading';
 
 const DriverMainPage: React.FC = () => {
   const { loading, error, data } = useQuery(CHECK_IS_WAITING);
-  const [isWorking, setIsWorking] = useState(false);
+  const [isWaiting, setIsWaiting] = useState(false);
 
   useEffect(() => {
-    if (!loading && data) setIsWorking(data.isDriverWaiting);
+    if (!loading && data) setIsWaiting(data.isDriverWaiting);
   }, [loading, data]);
 
   return loading ? (
     <Loading />
   ) : (
     <Wrapper>
-      <WorkingToggle onChange={setIsWorking} checked={isWorking} />
-      <DriverMainBody isWorking={isWorking} />
+      <WorkingToggle onChange={setIsWaiting} checked={isWaiting} />
+      <DriverMainBody isWaiting={isWaiting} />
       <Menu type="driver" />
     </Wrapper>
   );

--- a/client/src/pages/driver/DriverMainPage.tsx
+++ b/client/src/pages/driver/DriverMainPage.tsx
@@ -1,15 +1,25 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import WorkingToggle from '@components/driverMain/WorkingToggle';
 import DriverMainBody from '@components/driverMain/DriverMainBody';
 import styled from 'styled-components';
 import Menu from '@components/common/Menu';
+import { CHECK_IS_WAITING } from '@queries/driver/driverMatching';
+import { useQuery } from '@apollo/client';
+import Loading from '@components/common/Loading';
 
 const DriverMainPage: React.FC = () => {
+  const { loading, error, data } = useQuery(CHECK_IS_WAITING);
   const [isWorking, setIsWorking] = useState(false);
 
-  return (
+  useEffect(() => {
+    if (!loading && data) setIsWorking(data.isDriverWaiting);
+  }, [loading, data]);
+
+  return loading ? (
+    <Loading />
+  ) : (
     <Wrapper>
-      <WorkingToggle onChange={setIsWorking} />
+      <WorkingToggle onChange={setIsWorking} checked={isWorking} />
       <DriverMainBody isWorking={isWorking} />
       <Menu type="driver" />
     </Wrapper>

--- a/client/src/queries/driver/driverMatching.ts
+++ b/client/src/queries/driver/driverMatching.ts
@@ -26,3 +26,9 @@ export const ARRIVE_DESTINATION = gql`
     }
   }
 `;
+
+export const CHECK_IS_WAITING = gql`
+  query {
+    isDriverWaiting
+  }
+`;

--- a/server/graphql/resolver/query.ts
+++ b/server/graphql/resolver/query.ts
@@ -1,3 +1,5 @@
+import { logger } from '../../config/winston';
+
 const Query = {
   isAuthorizedUser: () => true,
   isAuthorizedDriver: () => true,
@@ -7,6 +9,17 @@ const Query = {
     const [firstDataIdx, endDataIdx] = [(page - 1) * 10, page * 10];
     const userHistoryOnPage = userHistoryAll.slice(firstDataIdx, endDataIdx);
     return userHistoryOnPage;
+  },
+  isDriverWaiting: async (_, __, { dataSources, uid }) => {
+    try {
+      const waitingDriverSchema = dataSources.model('WaitingDriver');
+      const waitingDriver = await waitingDriverSchema.find({ driver: uid });
+      logger.info(`isDriverWaiting check ${!!waitingDriver.length}`);
+      return waitingDriver.length;
+    } catch (error) {
+      logger.error(`isDriverWaiting ERROR: ${error}`);
+      return false;
+    }
   },
 };
 export default Query;

--- a/server/graphql/schema/index.graphql
+++ b/server/graphql/schema/index.graphql
@@ -7,6 +7,7 @@ type Query {
   users: String
   isAuthorizedUser: Boolean @auth(requires: USER)
   isAuthorizedDriver: Boolean @auth(requires: DRIVER)
+  isDriverWaiting: Boolean @auth(requires: DRIVER)
   userHistory(page: Int): [UserHistoryResult] @auth(requires: USER)
 }
 


### PR DESCRIPTION
## 해당 이슈 📎

#130

## 변경 사항 🛠

- 드라이버가 메인 화면에 진입 했을 때 서버로 query를 보내 드라이버가 영업중인지 확인하고 영업중이라면 영업중으로 표시되게 구현

## 테스트 ✨

![checkservice](https://user-images.githubusercontent.com/44524462/101715261-754c0880-3ade-11eb-997a-563440a973e7.gif)

## 리뷰어 참고 사항 🙋‍♀️

- 글쓰기 너무 힘들어요 ㅠㅠㅠ