### PR TITLE
history 조회 query 수정

### DIFF
--- a/server/graphql/resolver/mutation.ts
+++ b/server/graphql/resolver/mutation.ts
@@ -194,7 +194,7 @@ const Mutation = {
       const requestingUserModel = dataSources.model('RequestingUser');
       const result = await requestingUserModel.deleteOne({ user_id: mongoose.Types.ObjectId(uid) });
       if (!result.deletedCount) return { success: false, message: '이미 배차가 완료된 요청입니다.' };
-      
+
       const waitingDriverModel = dataSources.model('WaitingDriver');
       const matchedDriver = await waitingDriverModel
         .findOne({ driver: mongoose.Types.ObjectId(driverId) })

--- a/server/graphql/resolver/query.ts
+++ b/server/graphql/resolver/query.ts
@@ -5,12 +5,10 @@ const Query = {
   isAuthorizedDriver: () => true,
   userHistory: async (_, { page }, { dataSources, uid }) => {
     const UserHistory = await dataSources.model('UserHistory');
-    const userHistoryAll = await UserHistory.find({ user_id: uid })
+    const userHistoryOnPage = await UserHistory.find({ user_id: uid })
       .sort({ startTime: 'desc' })
       .skip((page - 1) * 10)
       .limit(10);
-    const [firstDataIdx, endDataIdx] = [(page - 1) * 10, page * 10];
-    const userHistoryOnPage = userHistoryAll.slice(firstDataIdx, endDataIdx);
     return userHistoryOnPage;
   },
   isDriverWaiting: async (_, __, { dataSources, uid }) => {

--- a/server/graphql/resolver/query.ts
+++ b/server/graphql/resolver/query.ts
@@ -5,7 +5,10 @@ const Query = {
   isAuthorizedDriver: () => true,
   userHistory: async (_, { page }, { dataSources, uid }) => {
     const UserHistory = await dataSources.model('UserHistory');
-    const userHistoryAll = await UserHistory.find({ user_id: uid });
+    const userHistoryAll = await UserHistory.find({ user_id: uid })
+      .sort({ startTime: 'desc' })
+      .skip((page - 1) * 10)
+      .limit(10);
     const [firstDataIdx, endDataIdx] = [(page - 1) * 10, page * 10];
     const userHistoryOnPage = userHistoryAll.slice(firstDataIdx, endDataIdx);
     return userHistoryOnPage;


### PR DESCRIPTION
## 해당 이슈 📎

#118 

## 변경 사항 🛠

mongoose `.skip`,`.limit`  활용
- 시간 역순 정렬
- 페이지당 10개 데이터

## 테스트 ✨

## 리뷰어 참고 사항 🙋‍♀️
- 진우님이 말씀하셨던 history 저장이 안되는 버그는 현재 잘 돌아가므로 따로 수정하지 않았습니다. 혹시 같은 버그가 보이면 알려주세요! 